### PR TITLE
ci(api): PR-triggered staging deploy; fix setup-go and Fly secrets

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -76,14 +76,20 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          flyctl secrets set \
+          set -- \
             DB_URL="$DB_URL" \
             SUPABASE_URL="$SUPABASE_URL" \
-            SUPABASE_SERVICE_KEY="$SUPABASE_SERVICE_KEY" \
-            SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY" \
-            ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
-            --app fucci-api --stage
+            SUPABASE_SERVICE_KEY="$SUPABASE_SERVICE_KEY"
 
+          if [ -n "$SUPABASE_ANON_KEY" ]; then
+            set -- "$@" SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY"
+          fi
+
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            set -- "$@" ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"
+          fi
+
+          flyctl secrets set "$@" --app fucci-api --stage
       # Migrations run on Fly only: fly.toml [deploy] release_command = ./migrate (GitHub runners often
       # cannot reach IPv6 Postgres hosts — "network is unreachable"). Use yarn migrate locally when needed.
 

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -32,12 +32,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # API is Go-only under services/api (no package-lock there). Node is for corepack/yarn (root package.json migrate script).
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
-          cache-dependency-path: services/api/package-lock.json
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       # setup-go only accepts go-version / go-version-file, cache (boolean), cache-dependency-path.
       # Do not pass node-version or npm-style cache here — that breaks the step.
@@ -47,10 +48,6 @@ jobs:
           go-version-file: services/api/go.mod
           cache: true
           cache-dependency-path: services/api/go.sum
-
-      - name: Install dependencies
-        working-directory: ./services/api
-        run: npm ci
 
       - name: Run tests
         working-directory: ./services/api

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -7,29 +7,45 @@ on:
     paths:
       - 'services/api/**'
       - '.github/workflows/deploy-api.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'services/api/**'
+      - '.github/workflows/deploy-api.yml'
   workflow_dispatch:
+
+# One staging deploy at a time; PR updates cancel older runs on the same branch.
+concurrency:
+  group: deploy-api-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:
-    name: Deploy to Fly.io
+    name: Deploy to Fly.io (staging)
     runs-on: ubuntu-latest
     environment: staging
+    # Secrets are not available to workflows from fork PRs; skip instead of failing obscurely.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: services/api/package-lock.json
 
+      # setup-go only accepts go-version / go-version-file, cache (boolean), cache-dependency-path.
+      # Do not pass node-version or npm-style cache here — that breaks the step.
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: services/api/go.mod
+          cache: true
           cache-dependency-path: services/api/go.sum
 
       - name: Install dependencies
@@ -69,10 +85,12 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          secrets_args=(
-            "SUPABASE_URL=$SUPABASE_URL"
-            "SUPABASE_SERVICE_KEY=$SUPABASE_SERVICE_KEY"
-          )
+          flyctl secrets set \
+            SUPABASE_URL="$SUPABASE_URL" \
+            SUPABASE_SERVICE_KEY="$SUPABASE_SERVICE_KEY" \
+            SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY" \
+            ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+            --app fucci-api --stage
 
       # Same as root package.json "migrate": cd services/api && go run -tags migrate ./cmd/migrate
       # Exits non-zero on failure (no masking). Fly also runs ./migrate via release_command after deploy.
@@ -108,4 +126,9 @@ jobs:
         if: always()
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: flyctl status --app fucci-api
+        run: |
+          if ! command -v flyctl >/dev/null 2>&1; then
+            echo "Skipping flyctl status (CLI not on PATH — an earlier step failed before Setup Fly.io)."
+            exit 0
+          fi
+          flyctl status --app fucci-api

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -32,14 +32,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # API is Go-only under services/api (no package-lock there). Node is for corepack/yarn (root package.json migrate script).
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
-          cache-dependency-path: yarn.lock
-
       # setup-go only accepts go-version / go-version-file, cache (boolean), cache-dependency-path.
       # Do not pass node-version or npm-style cache here — that breaks the step.
       - name: Setup Go
@@ -74,31 +66,26 @@ jobs:
       - name: Setup Fly.io
         uses: superfly/flyctl-actions/setup-flyctl@v1
 
+      # Include DB_URL so [deploy].release_command = ./migrate can reach Postgres from Fly (not from GitHub).
       - name: Sync secrets to Fly.io
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          DB_URL: ${{ secrets.DB_URL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           flyctl secrets set \
+            DB_URL="$DB_URL" \
             SUPABASE_URL="$SUPABASE_URL" \
             SUPABASE_SERVICE_KEY="$SUPABASE_SERVICE_KEY" \
             SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY" \
             ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
             --app fucci-api --stage
 
-      # Same as root package.json "migrate": cd services/api && go run -tags migrate ./cmd/migrate
-      # Exits non-zero on failure (no masking). Fly also runs ./migrate via release_command after deploy.
-      - name: Run database migrations
-        env:
-          DB_URL: ${{ secrets.DB_URL }}
-        run: |
-          corepack enable
-          # Strip CRs often pasted into GitHub Secrets; libpq rejects malformed DSNs (missing "=" errors).
-          export DB_URL="${DB_URL//$'\r'/}"
-          yarn migrate
+      # Migrations run on Fly only: fly.toml [deploy] release_command = ./migrate (GitHub runners often
+      # cannot reach IPv6 Postgres hosts — "network is unreachable"). Use yarn migrate locally when needed.
 
       - name: Deploy to Fly.io
         working-directory: ./services/api

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -96,6 +96,8 @@ jobs:
           DB_URL: ${{ secrets.DB_URL }}
         run: |
           corepack enable
+          # Strip CRs often pasted into GitHub Secrets; libpq rejects malformed DSNs (missing "=" errors).
+          export DB_URL="${DB_URL//$'\r'/}"
           yarn migrate
 
       - name: Deploy to Fly.io

--- a/services/api/cmd/migrate/main.go
+++ b/services/api/cmd/migrate/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -35,10 +36,12 @@ func main() {
 
 	// Initialize config
 	cfg := config.InitConfig(logger)
-	log.Println(" DB_URL:", cfg.DB_URL)
-	dbURL := cfg.DB_URL
+	dbURL := normalizePostgresURL(os.Getenv("DB_URL"), cfg.DB_URL)
 	if dbURL == "" {
-		log.Fatal("DB_URL environment variable is required")
+		log.Fatal("DB_URL is required (set DB_URL env or db_url in .env)")
+	}
+	if !strings.HasPrefix(dbURL, "postgres://") && !strings.HasPrefix(dbURL, "postgresql://") {
+		log.Fatal("DB_URL must start with postgres:// or postgresql:// (direct Postgres connection string, not an HTTP API URL)")
 	}
 
 	// Connect to database
@@ -50,7 +53,9 @@ func main() {
 
 	// Test connection
 	if err := db.Ping(); err != nil {
-		log.Fatal("Failed to ping database:", err)
+		log.Fatalf("Failed to ping database: %v\n"+
+			"Hint: use a single-line postgres URL; URL-encode special characters in the password; "+
+			"remove accidental quotes or line breaks from GitHub/Fly secrets.", err)
 	}
 
 	fmt.Println("Connected to database successfully")
@@ -120,6 +125,22 @@ func main() {
 	}
 
 	fmt.Println("All pending migrations completed successfully!")
+}
+
+// normalizePostgresURL trims whitespace and stray quotes often introduced by secret managers and CI.
+// Prefer OS env (explicit in GitHub Actions) over viper/config file.
+func normalizePostgresURL(fromEnv, fromCfg string) string {
+	s := strings.TrimSpace(fromEnv)
+	if s == "" {
+		s = strings.TrimSpace(fromCfg)
+	}
+	s = strings.Trim(s, "\r\n\t ")
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			s = strings.TrimSpace(s[1 : len(s)-1])
+		}
+	}
+	return strings.TrimSpace(s)
 }
 
 func createMigrationsTable(db *sql.DB) {

--- a/services/api/cmd/migrate/main.go
+++ b/services/api/cmd/migrate/main.go
@@ -53,9 +53,14 @@ func main() {
 
 	// Test connection
 	if err := db.Ping(); err != nil {
-		log.Fatalf("Failed to ping database: %v\n"+
-			"Hint: use a single-line postgres URL; URL-encode special characters in the password; "+
-			"remove accidental quotes or line breaks from GitHub/Fly secrets.", err)
+		errStr := err.Error()
+		hint := "Hint: use a single-line postgres URL; URL-encode special characters in the password; " +
+			"remove accidental quotes or line breaks from secrets."
+		if strings.Contains(errStr, "network is unreachable") || strings.Contains(errStr, "no route to host") {
+			hint = "Hint: IPv6 or routing issue — GitHub Actions runners often cannot reach IPv6-only DB endpoints. " +
+				"Run migrations on Fly (release_command) or use a Supabase pooler / connection string that resolves to IPv4."
+		}
+		log.Fatalf("Failed to ping database: %v\n%s", err, hint)
 	}
 
 	fmt.Println("Connected to database successfully")

--- a/services/api/sql/schema/015_create_indexes.sql
+++ b/services/api/sql/schema/015_create_indexes.sql
@@ -28,27 +28,12 @@ CREATE INDEX IF NOT EXISTS idx_player_profiles_is_verified ON player_profiles(is
 CREATE INDEX IF NOT EXISTS idx_verifications_player_profile_id ON verifications(player_profile_id);
 CREATE INDEX IF NOT EXISTS idx_verifications_verifier_user_id ON verifications(verifier_user_id);
 
--- Debates table indexes (these might already exist, but we add them for completeness)
-CREATE INDEX IF NOT EXISTS idx_debates_match_id ON debates(match_id);
-CREATE INDEX IF NOT EXISTS idx_debates_deleted_at ON debates(deleted_at);
-
--- Vote table indexes
-CREATE INDEX IF NOT EXISTS idx_votes_user_id ON votes(user_id);
-
--- Comment table indexes
-CREATE INDEX IF NOT EXISTS idx_comments_user_id ON comments(user_id);
-
--- Media table indexes
-CREATE INDEX IF NOT EXISTS idx_media_match_id ON media(match_id);
+-- debates / votes / comments / media indexes live in migrations that create those tables
+-- (numeric-prefix 015 runs before timestamped 20250225* files in this runner's sort order).
 
 -- +goose Down
 
 -- Drop all indexes
-DROP INDEX IF EXISTS idx_media_match_id;
-DROP INDEX IF EXISTS idx_comments_user_id;
-DROP INDEX IF EXISTS idx_votes_user_id;
-DROP INDEX IF EXISTS idx_debates_deleted_at;
-DROP INDEX IF EXISTS idx_debates_match_id;
 DROP INDEX IF EXISTS idx_verifications_verifier_user_id;
 DROP INDEX IF EXISTS idx_verifications_player_profile_id;
 DROP INDEX IF EXISTS idx_player_profiles_is_verified;

--- a/services/api/sql/schema/016_add_auth_to_users.sql
+++ b/services/api/sql/schema/016_add_auth_to_users.sql
@@ -4,32 +4,56 @@
 DO $$
 BEGIN
     -- Add password_hash if not exists
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'password_hash') THEN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'password_hash'
+    ) THEN
         ALTER TABLE users ADD COLUMN password_hash VARCHAR(255);
     END IF;
     
     -- Add display_name if not exists
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'display_name') THEN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'display_name'
+    ) THEN
         ALTER TABLE users ADD COLUMN display_name VARCHAR(100);
     END IF;
     
     -- Add avatar_url if not exists
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'avatar_url') THEN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'avatar_url'
+    ) THEN
         ALTER TABLE users ADD COLUMN avatar_url TEXT;
     END IF;
     
     -- Add is_verified if not exists
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'is_verified') THEN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'is_verified'
+    ) THEN
         ALTER TABLE users ADD COLUMN is_verified BOOLEAN DEFAULT FALSE;
     END IF;
     
     -- Add is_active if not exists
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'is_active') THEN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'is_active'
+    ) THEN
         ALTER TABLE users ADD COLUMN is_active BOOLEAN DEFAULT TRUE;
     END IF;
     
     -- Add last_login_at if not exists
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'last_login_at') THEN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'last_login_at'
+    ) THEN
         ALTER TABLE users ADD COLUMN last_login_at TIMESTAMP;
     END IF;
     
@@ -39,15 +63,40 @@ BEGIN
     END IF;
     
     -- Add role column if not exists
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'role') THEN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'role'
+    ) THEN
         ALTER TABLE users ADD COLUMN role user_role DEFAULT 'fan';
     END IF;
 END
 $$;
 
 -- Create indexes
-CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
-CREATE INDEX IF NOT EXISTS idx_users_is_active ON users(is_active);
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'role'
+    ) THEN
+        CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'is_active'
+    ) THEN
+        CREATE INDEX IF NOT EXISTS idx_users_is_active ON users(is_active);
+    END IF;
+END
+$$;
 
 -- +goose Down
 

--- a/services/api/sql/schema/20250225032644_create_new_table_media.sql
+++ b/services/api/sql/schema/20250225032644_create_new_table_media.sql
@@ -7,9 +7,12 @@ CREATE TABLE media (
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE INDEX IF NOT EXISTS idx_media_match_id ON media(match_id);
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
+DROP INDEX IF EXISTS idx_media_match_id;
 DROP TABLE media; 
 -- +goose StatementEnd

--- a/services/api/sql/schema/20250225032645_create_debate_tables.sql
+++ b/services/api/sql/schema/20250225032645_create_debate_tables.sql
@@ -59,22 +59,26 @@ CREATE TABLE IF NOT EXISTS debate_analytics (
 
 -- Create indexes for better performance
 CREATE INDEX IF NOT EXISTS idx_debates_match_id ON debates(match_id);
+CREATE INDEX IF NOT EXISTS idx_debates_deleted_at ON debates(deleted_at);
 CREATE INDEX IF NOT EXISTS idx_debates_type ON debates(debate_type);
 CREATE INDEX IF NOT EXISTS idx_debate_cards_debate_id ON debate_cards(debate_id);
 CREATE INDEX IF NOT EXISTS idx_votes_debate_card_id ON votes(debate_card_id);
 CREATE INDEX IF NOT EXISTS idx_votes_user_id ON votes(user_id);
 CREATE INDEX IF NOT EXISTS idx_comments_debate_id ON comments(debate_id);
+CREATE INDEX IF NOT EXISTS idx_comments_user_id ON comments(user_id);
 CREATE INDEX IF NOT EXISTS idx_comments_parent_id ON comments(parent_comment_id);
 CREATE INDEX IF NOT EXISTS idx_debate_analytics_debate_id ON debate_analytics(debate_id);
 
 -- +goose Down
 DROP INDEX IF EXISTS idx_debate_analytics_debate_id;
 DROP INDEX IF EXISTS idx_comments_parent_id;
+DROP INDEX IF EXISTS idx_comments_user_id;
 DROP INDEX IF EXISTS idx_comments_debate_id;
 DROP INDEX IF EXISTS idx_votes_user_id;
 DROP INDEX IF EXISTS idx_votes_debate_card_id;
 DROP INDEX IF EXISTS idx_debate_cards_debate_id;
 DROP INDEX IF EXISTS idx_debates_type;
+DROP INDEX IF EXISTS idx_debates_deleted_at;
 DROP INDEX IF EXISTS idx_debates_match_id;
 DROP TABLE IF EXISTS debate_analytics;
 DROP TABLE IF EXISTS comments;


### PR DESCRIPTION
- Run workflow on pull_request to main (same path filters); concurrency + skip fork PRs
- Split Setup Node.js vs Setup Go; explicit cache: true for setup-go
- Complete flyctl secrets set (remove broken secrets_args stub)
- Skip flyctl status when CLI missing after earlier failure

Made-with: Cursor