### PR TITLE
Improve debate generation quality and tighten the debates feed.

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -51,6 +51,7 @@ import MatchTeamShortsScreen from './src/screens/MatchTeamShortsScreen';
 // Types
 import type {RootStackParamList} from './src/types/navigation';
 import {prepareApp} from './src/bootstrap/prepareApp';
+import {useAppPortraitLock} from './src/hooks/useAppPortraitLock';
 
 const Tab = createBottomTabNavigator();
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -390,6 +391,9 @@ const DebatesStack = () => {
 
 function App(): React.JSX.Element {
   const [appIsReady, setAppIsReady] = useState(false);
+  const [navState, setNavState] = useState<NavigationState | undefined>();
+
+  useAppPortraitLock(navState, appIsReady);
 
   useEffect(() => {
     let cancelled = false;
@@ -407,6 +411,17 @@ function App(): React.JSX.Element {
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  const onNavigationStateChange = useCallback(
+    (state: NavigationState | undefined) => {
+      setNavState(state);
+    },
+    [],
+  );
+
+  const onNavigationReady = useCallback(() => {
+    setNavState(rootNavigationRef.current?.getRootState());
   }, []);
 
   const onLayoutRootView = useCallback(async () => {
@@ -439,7 +454,10 @@ function App(): React.JSX.Element {
       <QueryClientProvider client={queryClient}>
         <SafeAreaProvider>
           <AuthProvider>
-            <NavigationContainer ref={rootNavigationRef}>
+            <NavigationContainer
+              ref={rootNavigationRef}
+              onStateChange={onNavigationStateChange}
+              onReady={onNavigationReady}>
               <Stack.Navigator screenOptions={{headerShown: false}}>
                 <Stack.Screen name="Main" component={MainStack} />
                 <Stack.Screen

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -10,6 +10,7 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
+      "requireFullScreen": true,
       "bundleIdentifier": "com.magistridev.fucci",
       "buildNumber": "4",
       "infoPlist": {
@@ -56,6 +57,12 @@
         {
           "photosPermission": "Allow Fucci to access your photos so you can choose profile pictures.",
           "cameraPermission": "Allow Fucci to use your camera so you can take profile pictures."
+        }
+      ],
+      [
+        "expo-screen-orientation",
+        {
+          "initialOrientation": "PORTRAIT_UP"
         }
       ]
     ],

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -51,6 +51,7 @@
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-secure-store": "~15.0.8",
+    "expo-screen-orientation": "~9.0.9",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-updates": "~29.0.16",

--- a/apps/mobile/src/components/YouTubeShortSlide.tsx
+++ b/apps/mobile/src/components/YouTubeShortSlide.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useEffect, useRef} from 'react';
 import {
   ActivityIndicator,
   StyleSheet,
+  useWindowDimensions,
   View,
 } from 'react-native';
 import {WebView} from 'react-native-webview';
@@ -22,6 +23,15 @@ const START_PLAYBACK_JS = `
   true;
 `;
 
+const RESIZE_PLAYER_JS = (width: number, height: number) => `
+  (function () {
+    if (window.resizeYouTubePlayer) {
+      window.resizeYouTubePlayer(${Math.round(width)}, ${Math.round(height)});
+    }
+  })();
+  true;
+`;
+
 type Props = {
   short: YouTubeShort;
   isActive: boolean;
@@ -35,6 +45,7 @@ export default function YouTubeShortSlide({
   onFinished,
   onPlaybackStart,
 }: Props) {
+  const {width, height} = useWindowDimensions();
   const webViewRef = useRef<WebView>(null);
   const finishedRef = useRef(onFinished);
   const onPlaybackStartRef = useRef(onPlaybackStart);
@@ -81,6 +92,22 @@ export default function YouTubeShortSlide({
     };
   }, [isActive, requestPlayback, short.video_id]);
 
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+    const resize = () => {
+      webViewRef.current?.injectJavaScript(RESIZE_PLAYER_JS(width, height));
+    };
+    resize();
+    const retry = setTimeout(resize, 200);
+    const retryLate = setTimeout(resize, 500);
+    return () => {
+      clearTimeout(retry);
+      clearTimeout(retryLate);
+    };
+  }, [isActive, width, height]);
+
   const onMessage = useCallback(
     (event: {nativeEvent: {data: string}}) => {
       try {
@@ -115,10 +142,10 @@ export default function YouTubeShortSlide({
           html: youtubeShortPlayerHtml(short.video_id),
           baseUrl: YOUTUBE_SHORT_PLAYER_BASE_URL,
         }}
-        style={styles.webview}
+        style={[styles.webview, {width, height}]}
         originWhitelist={['https://*', 'about:blank']}
         allowsInlineMediaPlayback
-        allowsFullscreenVideo={false}
+        allowsFullscreenVideo
         mediaPlaybackRequiresUserAction={false}
         allowsProtectedMedia
         sharedCookiesEnabled
@@ -126,6 +153,8 @@ export default function YouTubeShortSlide({
         domStorageEnabled
         scrollEnabled={false}
         bounces={false}
+        contentInsetAdjustmentBehavior="never"
+        automaticallyAdjustContentInsets={false}
         onLoadEnd={onWebViewLoadEnd}
         onMessage={onMessage}
         startInLoadingState

--- a/apps/mobile/src/hooks/useAppPortraitLock.ts
+++ b/apps/mobile/src/hooks/useAppPortraitLock.ts
@@ -1,0 +1,43 @@
+import {useEffect} from 'react';
+import {AppState, type AppStateStatus} from 'react-native';
+import type {NavigationState} from '@react-navigation/native';
+import {
+  isOrientationUnlockRoute,
+  lockAppPortrait,
+} from '../utils/screenOrientation';
+
+/**
+ * Keeps the app portrait-locked everywhere except MatchTeamShorts (news/match stories).
+ */
+export function useAppPortraitLock(
+  navigationState: NavigationState | undefined,
+  enabled: boolean,
+): void {
+  const onShortsScreen = isOrientationUnlockRoute(navigationState);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    lockAppPortrait();
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled || onShortsScreen) {
+      return;
+    }
+    lockAppPortrait();
+  }, [enabled, onShortsScreen]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const sub = AppState.addEventListener('change', (next: AppStateStatus) => {
+      if (next === 'active' && !isOrientationUnlockRoute(navigationState)) {
+        lockAppPortrait();
+      }
+    });
+    return () => sub.remove();
+  }, [enabled, navigationState]);
+}

--- a/apps/mobile/src/hooks/useAppPortraitLock.ts
+++ b/apps/mobile/src/hooks/useAppPortraitLock.ts
@@ -16,13 +16,6 @@ export function useAppPortraitLock(
   const onShortsScreen = isOrientationUnlockRoute(navigationState);
 
   useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-    lockAppPortrait();
-  }, [enabled]);
-
-  useEffect(() => {
     if (!enabled || onShortsScreen) {
       return;
     }

--- a/apps/mobile/src/screens/MainDebatesScreen.tsx
+++ b/apps/mobile/src/screens/MainDebatesScreen.tsx
@@ -44,7 +44,7 @@ const RED = '#FF3B30';
 const LIVE_DOT = '#3B82F6';
 
 /** NEW DEBATES and MY ACTIVITY use `created_at` within this window (generation time). */
-const FEED_MAX_AGE_MS = 6 * 24 * 60 * 60 * 1000;
+const FEED_MAX_AGE_MS = 48 * 60 * 60 * 1000;
 
 /**
  * Go encodes `time.Time` as RFC3339Nano. `Date.parse` often returns NaN when fractional
@@ -82,7 +82,7 @@ function debateRowTimeMs(summary: DebateSummary): number | null {
   );
 }
 
-function debateGeneratedWithinPastSixDays(
+function debateGeneratedWithinPast48Hours(
   summary: DebateSummary,
   nowMs: number,
 ): boolean {
@@ -109,7 +109,7 @@ function debatePassesActiveFilters(
   summary: DebateSummary,
   nowMs: number,
 ): boolean {
-  if (!debateGeneratedWithinPastSixDays(summary, nowMs)) {
+  if (!debateGeneratedWithinPast48Hours(summary, nowMs)) {
     return false;
   }
   if (WORLD_CUP_ONLY_MODE && !debateIsWorldCupRelated(summary)) {

--- a/apps/mobile/src/screens/MatchTeamShortsScreen.tsx
+++ b/apps/mobile/src/screens/MatchTeamShortsScreen.tsx
@@ -3,12 +3,17 @@ import {Animated, Pressable, StyleSheet, Text, View} from 'react-native';
 import PagerView from 'react-native-pager-view';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {
+  useFocusEffect,
   useNavigation,
   useRoute,
   type RouteProp,
 } from '@react-navigation/native';
 import type {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {Ionicons} from '@expo/vector-icons';
+import {
+  lockAppPortrait,
+  unlockAppOrientation,
+} from '../utils/screenOrientation';
 import YouTubeShortSlide from '../components/YouTubeShortSlide';
 import {
   parseYouTubeDurationSeconds,
@@ -18,6 +23,19 @@ import type {RootStackParamList} from '../types/navigation';
 
 const SHORT_RING_AMBER = '#F5A623';
 const PROGRESS_TRACK = 'rgba(255,255,255,0.35)';
+const PROGRESS_BAR_HEIGHT = 3;
+const HEADER_TOP_GAP = 8;
+const HEADER_SECTION_GAP = 10;
+const CLOSE_BUTTON_SIZE = 44;
+const HORIZONTAL_CHROME_INSET = 12;
+
+export function shortsHeaderLayout(insetsTop: number) {
+  const progressBarTop = insetsTop + HEADER_TOP_GAP;
+  const closeButtonTop =
+    progressBarTop + PROGRESS_BAR_HEIGHT + HEADER_SECTION_GAP;
+  const chromeBottom = closeButtonTop + CLOSE_BUTTON_SIZE;
+  return {progressBarTop, closeButtonTop, chromeBottom};
+}
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'MatchTeamShorts'>;
 type R = RouteProp<RootStackParamList, 'MatchTeamShorts'>;
@@ -27,6 +45,7 @@ export default function MatchTeamShortsScreen() {
   const {params} = useRoute<R>();
   const {shorts} = params;
   const insets = useSafeAreaInsets();
+  const headerLayout = shortsHeaderLayout(insets.top);
   const [page, setPage] = useState(0);
   const [playbackStarted, setPlaybackStarted] = useState(false);
   const progressAnim = useRef(new Animated.Value(0)).current;
@@ -39,6 +58,13 @@ export default function MatchTeamShortsScreen() {
     const sec = parseYouTubeDurationSeconds(currentShort?.duration ?? '');
     return Math.max(sec * 1000, 3000);
   }, [currentShort?.duration, currentShort?.video_id]);
+
+  useFocusEffect(
+    useCallback(() => {
+      unlockAppOrientation();
+      return lockAppPortrait;
+    }, []),
+  );
 
   useEffect(() => {
     progressAnim.setValue(0);
@@ -143,7 +169,13 @@ export default function MatchTeamShortsScreen() {
       <View style={[styles.root, styles.centered]}>
         <Text style={styles.hint}>No Shorts available right now.</Text>
         <Pressable
-          style={[styles.closeFab, {top: insets.top + 8}]}
+          style={[
+            styles.closeFab,
+            {
+              top: headerLayout.closeButtonTop,
+              left: HORIZONTAL_CHROME_INSET + insets.left,
+            },
+          ]}
           onPress={() => navigation.goBack()}
           hitSlop={12}
           accessibilityRole="button"
@@ -156,17 +188,15 @@ export default function MatchTeamShortsScreen() {
 
   return (
     <View style={styles.root} testID="MatchTeamShortsScreen">
-      <Pressable
-        style={[styles.closeFab, {top: insets.top + 8}]}
-        onPress={() => navigation.goBack()}
-        hitSlop={12}
-        accessibilityRole="button"
-        accessibilityLabel="Close">
-        <Ionicons name="close" size={26} color="#111" />
-      </Pressable>
-
       <View
-        style={[styles.progressBar, {top: insets.top + 10}]}
+        style={[
+          styles.progressBar,
+          {
+            top: headerLayout.progressBarTop,
+            left: HORIZONTAL_CHROME_INSET + insets.left,
+            right: HORIZONTAL_CHROME_INSET + insets.right,
+          },
+        ]}
         pointerEvents="none">
         {slides.map((_, i) => (
           <View key={i} style={styles.progressTrack}>
@@ -188,6 +218,21 @@ export default function MatchTeamShortsScreen() {
           </View>
         ))}
       </View>
+
+      <Pressable
+        style={[
+          styles.closeFab,
+          {
+            top: headerLayout.closeButtonTop,
+            left: HORIZONTAL_CHROME_INSET + insets.left,
+          },
+        ]}
+        onPress={() => navigation.goBack()}
+        hitSlop={12}
+        accessibilityRole="button"
+        accessibilityLabel="Close">
+        <Ionicons name="close" size={26} color="#111" />
+      </Pressable>
 
       <View style={styles.pagerWrap}>
         <PagerView
@@ -218,7 +263,7 @@ export default function MatchTeamShortsScreen() {
         <View
           style={[
             styles.tapZones,
-            {top: insets.top + 52, bottom: 100},
+            {top: headerLayout.chromeBottom + 8, bottom: 100},
           ]}
           pointerEvents={playbackStarted ? 'box-none' : 'none'}>
           <Pressable
@@ -274,11 +319,10 @@ const styles = StyleSheet.create({
   },
   closeFab: {
     position: 'absolute',
-    left: 12,
     zIndex: 10,
-    width: 44,
-    height: 44,
-    borderRadius: 22,
+    width: CLOSE_BUTTON_SIZE,
+    height: CLOSE_BUTTON_SIZE,
+    borderRadius: CLOSE_BUTTON_SIZE / 2,
     backgroundColor: 'rgba(255,255,255,0.94)',
     alignItems: 'center',
     justifyContent: 'center',
@@ -290,15 +334,13 @@ const styles = StyleSheet.create({
   },
   progressBar: {
     position: 'absolute',
-    left: 12,
-    right: 12,
     zIndex: 9,
     flexDirection: 'row',
     gap: 4,
   },
   progressTrack: {
     flex: 1,
-    height: 3,
+    height: PROGRESS_BAR_HEIGHT,
     borderRadius: 2,
     backgroundColor: PROGRESS_TRACK,
     overflow: 'hidden',

--- a/apps/mobile/src/screens/SingleDebateScreen.tsx
+++ b/apps/mobile/src/screens/SingleDebateScreen.tsx
@@ -492,9 +492,17 @@ const SingleDebateScreen = () => {
         </View>
         <View style={styles.commentBody}>
           <View style={styles.commentMetaRow}>
-            <Text style={styles.commentUsername}>
-              {c.user_display_name || 'User'}
-            </Text>
+            <View style={styles.commentMetaLeft}>
+              {c.is_fucci_take ? (
+                <View style={styles.fucciTakeBadge}>
+                  <Text style={styles.fucciTakeBadgeText}>Fucci's Take</Text>
+                </View>
+              ) : (
+                <Text style={styles.commentUsername}>
+                  {c.user_display_name || 'User'}
+                </Text>
+              )}
+            </View>
             <View style={styles.commentVoteRow}>
               <TouchableOpacity
                 onPress={() => handleCommentVote(c.id, 'upvote')}
@@ -1511,10 +1519,31 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     marginBottom: 4,
   },
+  commentMetaLeft: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginRight: 8,
+  },
   commentUsername: {
     fontSize: 14,
     fontWeight: '700',
     color: TEXT,
+  },
+  fucciTakeBadge: {
+    backgroundColor: 'rgba(190, 242, 100, 0.15)',
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  fucciTakeBadgeText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: LIME,
+    letterSpacing: 0.3,
+    textTransform: 'uppercase',
   },
   commentVoteRow: {
     flexDirection: 'row',

--- a/apps/mobile/src/services/__tests__/matchShortsApi.test.ts
+++ b/apps/mobile/src/services/__tests__/matchShortsApi.test.ts
@@ -5,6 +5,9 @@ import {
   hasTeamShorts,
   matchShortsQueryKey,
   parseYouTubeDurationSeconds,
+  youtubePlayerContainLayout,
+  youtubePlayerCoverLayout,
+  youtubePlayerShortsLayout,
   youtubeShortPlayerHtml,
   YOUTUBE_SHORT_PLAYER_BASE_URL,
   type MatchShortsTeam,
@@ -61,6 +64,51 @@ describe('matchShortsApi', () => {
     });
   });
 
+  describe('youtubePlayerContainLayout', () => {
+    it('fits the full Short frame in portrait without cropping', () => {
+      const baseHeight = Math.round(360 / (9 / 16));
+      const layout = youtubePlayerContainLayout(393, 852);
+      expect(layout.scale).toBe(Math.min(393 / 360, 852 / baseHeight));
+    });
+
+    it('fits the full Short frame in landscape without cropping', () => {
+      const baseHeight = Math.round(360 / (9 / 16));
+      const layout = youtubePlayerContainLayout(852, 393);
+      expect(layout.scale).toBe(Math.min(852 / 360, 393 / baseHeight));
+    });
+  });
+
+  describe('youtubePlayerShortsLayout', () => {
+    it('uses cover-fit in landscape for full screen', () => {
+      const baseHeight = Math.round(360 / (9 / 16));
+      const layout = youtubePlayerShortsLayout(852, 393);
+      expect(layout.isLandscape).toBe(true);
+      expect(layout.scale).toBe(Math.max(852 / 360, 393 / baseHeight));
+    });
+
+    it('uses contain-fit in portrait to avoid cropping', () => {
+      const baseHeight = Math.round(360 / (9 / 16));
+      const layout = youtubePlayerShortsLayout(393, 852);
+      expect(layout.isLandscape).toBe(false);
+      expect(layout.scale).toBe(Math.min(393 / 360, 852 / baseHeight));
+    });
+  });
+
+  describe('youtubePlayerCoverLayout', () => {
+    it('scales up to cover landscape viewport', () => {
+      const layout = youtubePlayerCoverLayout(852, 393, 9 / 16, 0);
+      expect(layout.baseWidth).toBe(360);
+      expect(layout.scale).toBeGreaterThanOrEqual(852 / 360);
+      expect(layout.baseHeight).toBe(Math.round(360 / (9 / 16)));
+    });
+
+    it('applies extra zoom when uiCropRatio is set', () => {
+      const noCrop = youtubePlayerCoverLayout(393, 852, 9 / 16, 0);
+      const cropped = youtubePlayerCoverLayout(393, 852, 9 / 16, 0.14);
+      expect(cropped.scale).toBeGreaterThan(noCrop.scale);
+    });
+  });
+
   describe('youtubeShortPlayerHtml', () => {
     it('embeds sanitized video id and iframe API hooks', () => {
       const html = youtubeShortPlayerHtml('Jf3zdhWWfe4');
@@ -71,6 +119,12 @@ describe('matchShortsApi', () => {
       expect(html).toContain('autoplay: 1');
       expect(html).not.toContain('mute: 1');
       expect(html).toContain('controls: 0');
+      expect(html).toContain("transform = 'scale('");
+      expect(html).toContain('resizeYouTubePlayer');
+      expect(html).toContain('isLandscape');
+      expect(html).toContain('Math.max(vw / baseW, vh / baseH)');
+      expect(html).toContain('Math.min(vw / baseW, vh / baseH)');
+      expect(html).toContain('fs: 0');
     });
 
     it('strips unsafe characters from video id', () => {

--- a/apps/mobile/src/services/matchShortsApi.ts
+++ b/apps/mobile/src/services/matchShortsApi.ts
@@ -52,8 +52,87 @@ export function parseYouTubeDurationSeconds(iso: string): number {
 export const YOUTUBE_SHORT_PLAYER_BASE_URL =
   'https://lonelycpp.github.io/react-native-youtube-iframe/';
 
+/** 9:16 — YouTube Shorts vertical aspect. */
+export const YOUTUBE_SHORT_VIDEO_ASPECT = 9 / 16;
+
 /**
- * Full-viewport YouTube IFrame API page for vertical Shorts (no 16:9 letterbox hack).
+ * Optional extra zoom after fit to trim Shorts iframe chrome (title, share).
+ * Set to 0 — chrome crop was clipping video content; YouTube has no hide API.
+ */
+export const YOUTUBE_SHORT_UI_CROP_RATIO = 0;
+
+/** Contain-fit layout — full Short frame visible, no edge crop. */
+export function youtubePlayerContainLayout(
+  viewportWidth: number,
+  viewportHeight: number,
+  videoAspect: number = YOUTUBE_SHORT_VIDEO_ASPECT,
+): {
+  baseWidth: number;
+  baseHeight: number;
+  scale: number;
+} {
+  const vw = Math.max(viewportWidth, 1);
+  const vh = Math.max(viewportHeight, 1);
+  const baseWidth = 360;
+  const baseHeight = Math.round(baseWidth / videoAspect);
+  const scale = Math.min(vw / baseWidth, vh / baseHeight);
+  return {baseWidth, baseHeight, scale};
+}
+
+/** Scale to cover viewport (fills screen; may crop edges). */
+export function youtubePlayerCoverLayout(
+  viewportWidth: number,
+  viewportHeight: number,
+  videoAspect: number = YOUTUBE_SHORT_VIDEO_ASPECT,
+  uiCropRatio: number = YOUTUBE_SHORT_UI_CROP_RATIO,
+): {
+  baseWidth: number;
+  baseHeight: number;
+  scale: number;
+} {
+  const vw = Math.max(viewportWidth, 1);
+  const vh = Math.max(viewportHeight, 1);
+  const baseWidth = 360;
+  const baseHeight = Math.round(baseWidth / videoAspect);
+  const coverScale = Math.max(vw / baseWidth, vh / baseHeight);
+  const crop = Math.min(Math.max(uiCropRatio, 0), 0.24);
+  const chromeZoom = crop > 0 ? 1 / (1 - 2 * crop) : 1;
+  return {baseWidth, baseHeight, scale: coverScale * chromeZoom};
+}
+
+/** Cover in landscape, contain in portrait — fullscreen rotate without portrait crop. */
+export function youtubePlayerShortsLayout(
+  viewportWidth: number,
+  viewportHeight: number,
+  videoAspect: number = YOUTUBE_SHORT_VIDEO_ASPECT,
+  uiCropRatio: number = YOUTUBE_SHORT_UI_CROP_RATIO,
+): {
+  baseWidth: number;
+  baseHeight: number;
+  scale: number;
+  isLandscape: boolean;
+} {
+  const vw = Math.max(viewportWidth, 1);
+  const vh = Math.max(viewportHeight, 1);
+  const isLandscape = vw > vh;
+  const baseWidth = 360;
+  const baseHeight = Math.round(baseWidth / videoAspect);
+  const fitScale = isLandscape
+    ? Math.max(vw / baseWidth, vh / baseHeight)
+    : Math.min(vw / baseWidth, vh / baseHeight);
+  const crop = Math.min(Math.max(uiCropRatio, 0), 0.24);
+  const chromeZoom = crop > 0 ? 1 / (1 - 2 * crop) : 1;
+  return {
+    baseWidth,
+    baseHeight,
+    scale: fitScale * chromeZoom,
+    isLandscape,
+  };
+}
+
+/**
+ * Full-viewport YouTube IFrame API page for vertical Shorts.
+ * Cover-fit in landscape (full screen); contain-fit in portrait (no video crop).
  */
 export function youtubeShortPlayerHtml(videoId: string): string {
   const safeId = videoId.replace(/[^a-zA-Z0-9_-]/g, '');
@@ -74,9 +153,14 @@ export function youtubeShortPlayerHtml(videoId: string): string {
       }
       #player {
         position: fixed;
-        inset: 0;
-        width: 100%;
-        height: 100%;
+        left: 50%;
+        top: 50%;
+        transform-origin: center center;
+        overflow: hidden;
+      }
+      #player iframe {
+        width: 100% !important;
+        height: 100% !important;
       }
     </style>
   </head>
@@ -107,12 +191,48 @@ export function youtubeShortPlayerHtml(videoId: string): string {
         } catch (e) {}
       }
       window.startYouTubePlayback = startPlayback;
+      var VIDEO_ASPECT = ${YOUTUBE_SHORT_VIDEO_ASPECT};
+      var UI_CROP = ${YOUTUBE_SHORT_UI_CROP_RATIO};
+      function resizePlayer(optW, optH) {
+        var vw = (typeof optW === 'number' && optW > 0) ? optW : window.innerWidth;
+        var vh = (typeof optH === 'number' && optH > 0) ? optH : window.innerHeight;
+        var baseW = 360;
+        var baseH = Math.round(baseW / VIDEO_ASPECT);
+        var isLandscape = vw > vh;
+        var fitScale = isLandscape
+          ? Math.max(vw / baseW, vh / baseH)
+          : Math.min(vw / baseW, vh / baseH);
+        var crop = Math.min(Math.max(UI_CROP, 0), 0.24);
+        var scale = fitScale * (crop > 0 ? 1 / (1 - 2 * crop) : 1);
+        var el = document.getElementById('player');
+        if (el) {
+          el.style.width = baseW + 'px';
+          el.style.height = baseH + 'px';
+          el.style.marginLeft = (-baseW / 2) + 'px';
+          el.style.marginTop = (-baseH / 2) + 'px';
+          el.style.transform = 'scale(' + scale + ')';
+        }
+        if (player && player.setSize) {
+          try {
+            player.setSize(baseW, baseH);
+          } catch (e) {}
+        }
+      }
+      window.resizeYouTubePlayer = resizePlayer;
+      window.addEventListener('resize', resizePlayer);
+      window.addEventListener('orientationchange', function () {
+        setTimeout(function () { resizePlayer(); }, 150);
+        setTimeout(function () { resizePlayer(); }, 400);
+      });
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener('resize', function () {
+          resizePlayer(window.visualViewport.width, window.visualViewport.height);
+        });
+      }
       function onYouTubeIframeAPIReady() {
-        var w = window.innerWidth;
-        var h = window.innerHeight;
         player = new YT.Player('player', {
-          width: w,
-          height: h,
+          width: 360,
+          height: Math.round(360 / VIDEO_ASPECT),
           videoId: '${safeId}',
           playerVars: {
             autoplay: 1,
@@ -122,11 +242,13 @@ export function youtubeShortPlayerHtml(videoId: string): string {
             modestbranding: 1,
             fs: 0,
             iv_load_policy: 3,
+            cc_load_policy: 0,
             disablekb: 1,
             origin: window.location.origin,
           },
           events: {
             onReady: function () {
+              resizePlayer();
               startPlayback();
               setTimeout(startPlayback, 200);
               setTimeout(startPlayback, 600);

--- a/apps/mobile/src/types/debate.ts
+++ b/apps/mobile/src/types/debate.ts
@@ -150,7 +150,7 @@ export interface ReactionCount {
   count: number;
 }
 
-/** Comment from GET /debates/:id/comments — top-level and subcomments, no stance/seeded in API */
+/** Comment from GET /debates/:id/comments — top-level and subcomments */
 export interface DebateComment {
   id: number;
   debate_id: number;
@@ -161,6 +161,7 @@ export interface DebateComment {
   content: string;
   created_at: string;
   net_score: number;
+  is_fucci_take?: boolean;
   current_user_vote?: 'upvote' | 'downvote' | null;
   reactions: ReactionCount[];
   subcomments?: DebateComment[];

--- a/apps/mobile/src/utils/screenOrientation.ts
+++ b/apps/mobile/src/utils/screenOrientation.ts
@@ -5,13 +5,13 @@ import * as ScreenOrientation from 'expo-screen-orientation';
 export const ORIENTATION_UNLOCK_ROUTE = 'MatchTeamShorts';
 
 export function lockAppPortrait(): void {
-  void ScreenOrientation.lockAsync(
+  ScreenOrientation.lockAsync(
     ScreenOrientation.OrientationLock.PORTRAIT_UP,
-  );
+  ).catch(() => {});
 }
 
 export function unlockAppOrientation(): void {
-  void ScreenOrientation.unlockAsync();
+  ScreenOrientation.unlockAsync().catch(() => {});
 }
 
 export function getActiveRouteName(

--- a/apps/mobile/src/utils/screenOrientation.ts
+++ b/apps/mobile/src/utils/screenOrientation.ts
@@ -1,0 +1,35 @@
+import type {NavigationState} from '@react-navigation/native';
+import * as ScreenOrientation from 'expo-screen-orientation';
+
+/** Route that may rotate (news + match YouTube Shorts). */
+export const ORIENTATION_UNLOCK_ROUTE = 'MatchTeamShorts';
+
+export function lockAppPortrait(): void {
+  void ScreenOrientation.lockAsync(
+    ScreenOrientation.OrientationLock.PORTRAIT_UP,
+  );
+}
+
+export function unlockAppOrientation(): void {
+  void ScreenOrientation.unlockAsync();
+}
+
+export function getActiveRouteName(
+  state: NavigationState | undefined,
+): string | undefined {
+  if (!state) {
+    return undefined;
+  }
+  const route = state.routes[state.index];
+  const nested = route.state as NavigationState | undefined;
+  if (nested) {
+    return getActiveRouteName(nested);
+  }
+  return route.name;
+}
+
+export function isOrientationUnlockRoute(
+  state: NavigationState | undefined,
+): boolean {
+  return getActiveRouteName(state) === ORIENTATION_UNLOCK_ROUTE;
+}

--- a/services/api/internal/ai/prompt_generator.go
+++ b/services/api/internal/ai/prompt_generator.go
@@ -34,6 +34,7 @@ type MatchData struct {
 	Venue              string           `json:"venue,omitempty"`
 	League             string           `json:"league,omitempty"`
 	Season             string           `json:"season,omitempty"`
+	Round              string           `json:"round,omitempty"` // e.g. "Round of 32", "Group Stage - 3"
 	HeadToHeadSummary  string           `json:"head_to_head_summary,omitempty"`
 	LeagueTableSummary string           `json:"league_table_summary,omitempty"`
 }
@@ -286,44 +287,91 @@ func extractJSONArrayFromContent(content string) string {
 	return strings.TrimSpace(s)
 }
 
+// debateRelevanceGuidelines returns shared instructions for match-specific, practical debates.
+func debateRelevanceGuidelines(phase string) string {
+	stageNote := ""
+	if phase == "pre_match" {
+		stageNote = `
+PRE-MATCH relevance:
+- Frame stakes for THIS fixture only — not the whole season or tournament arc.
+- In knockout rounds (Round of 16, Round of 32, quarterfinal, etc.): sudden-death pressure, one bad night ends it, favorite vs underdog — NOT "can they win the World Cup?"
+- In group stage: qualification math, must-win pressure, rotation risks — NOT premature title-contender coronations.
+- It is too early in a tournament to treat any team as a proven champion or long-run favorite unless the user message explicitly supports that with current-round context.`
+	} else {
+		stageNote = `
+POST-MATCH relevance:
+- Debate what happened in THIS match — a call, a player, a moment, a tactical choice.
+- Do not pivot to generic "they're winning it all" or season-long hype unless directly tied to this result.`
+	}
+
+	return `
+MATCH-SPECIFIC RELEVANCE (critical — use the user message data for THIS fixture):
+
+DO NOT generate lazy, generic debates such as:
+- "Team A vs Team B: who wins this showdown?"
+- "Classic giants or rising stars"
+- "Can [team] go all the way?" / title-favorite / golden-generation hype when the round does not warrant it
+- Vague narratives that could apply to any match between these teams
+
+DO generate practical, scroll-stopping debates anchored in THIS match:
+- Named players: should X start or be benched? injury return risk? key matchup? (use LINEUPS when provided)
+- Head-to-head history and what past meetings imply for tonight
+- Upset alerts, underdog cases, favorite pressure, knockout nerves
+- Specific concerns: missing players, defensive holes, set pieces, manager calls, fatigue, travel
+- When NEWS HEADLINES are provided in the user message: ground the debate in at least one recent headline — cite the storyline (injury news, selection drama, quotes, form piece) in the headline or description. Do not ignore headlines.
+
+Headlines should name players, tactical choices, or concrete storylines — not just two flags facing off.
+Descriptions should explain why NOW: the round/stage, a news item, a H2H fact, or a lineup question.` + stageNote
+}
+
 func (pg *PromptGenerator) buildSystemPrompt(promptType string) string {
+	reference := ReferenceDebatesPromptSection()
+	relevance := debateRelevanceGuidelines(promptType)
 	if promptType == "pre_match" {
-		return `You are a football debate prompt generator for a mobile app where each debate gets ONE community vote: users swipe agree or disagree with a single proposition.
+		return `You are Fucci's elite football debate producer for a mobile app where each debate gets ONE community vote: users swipe agree or disagree with a single proposition.
 
 IMPORTANT: PRE-MATCH — the match has NOT happened yet. No final scores or post-match outcomes.
 
-The headline must read as a clear and plain language statement or question fans can answer YES or NO to (agree vs disagree). Frame it so "agree" and "disagree" are natural opposites.
+Quality bar: headlines must be bold, specific, and polarizing — the kind of take that stops a fan mid-scroll. Descriptions should raise stakes with real context tied to this fixture. Study the reference corpus below for tone; adapt it to THIS match's players, round, news, and H2H — do not copy generic "who wins" framing.` + relevance + `
+
+The headline must read as a clear plain-language statement or question fans can answer YES or NO to (agree vs disagree). Frame it so "agree" and "disagree" are natural opposites.
 
 Respond with ONLY one JSON object (no markdown, no code fences, no extra text). Exact shape:
 {
-  "headline": "Bold, controversial line fans can agree or disagree with (e.g. claim or polarizing question)",
+  "headline": "Bold, controversial line fans can agree or disagree with",
   "description": "Short context that raises the stakes (why it matters for this fixture)",
   "cards": [
-    { "stance": "agree", "title": "Short label for the YES / agree side (e.g. how you'd vote if you buy the headline)" },
-    { "stance": "disagree", "title": "Short label for the NO / disagree side (e.g. how you'd vote if you reject the headline)" }
+    { "stance": "agree", "title": "Short label for the YES / agree side" },
+    { "stance": "disagree", "title": "Short label for the NO / disagree side" }
   ],
   "comments": [
-    "First comment: passionate fan voice backing the agree side",
-    "Second comment: passionate fan voice backing the disagree side",
-    "Third comment: spicy wildcard / hot-take or angle that still fits the debate (not analyst-speak)"
+    "Fucci's Take 1: passionate fan voice backing the agree side",
+    "Fucci's Take 2: passionate fan voice backing the disagree side",
+    "Fucci's Take 3: spicy wildcard / hot-take that still fits the debate"
   ]
 }
 
 Rules:
 - Exactly two cards: only "agree" and "disagree". No wildcard card. No third card.
 - Card objects use only "stance" and "title" (no per-card description field).
-- Exactly three strings in "comments". They seed the comments section before real users post.
-- Comments must sound like real supporters in the stands or group chat: emotional, direct, maybe messy, NEVER like a polished TV pundit. Avoid jargon stacks (e.g. don't lean on "low block", "xG", "progressive carries" unless a normal fan would say it). Short clauses, heat, banter, and belief are good.
+- Exactly three strings in "comments". These become pre-seeded "Fucci's Take" comments before real users post.
+- Comments must sound like real supporters in the stands or group chat: emotional, direct, maybe messy, NEVER like a polished TV pundit. Avoid jargon stacks unless a normal fan would say it. Short clauses, heat, banter, and belief are good.
 - Keep everything PG-13: no slurs, threats, hate, or harassment.
 
-Topic angles for pre-match:
-- Lineups, form, pressure, predictions, rivalries, manager calls, expectations.
+Strong pre-match angles (pick what fits THIS match — do not force all):
+- Lineup/selection calls, player starts and benches, injury returns
+- H2H history and psychological edge
+- Knockout upset potential or favorite vulnerability
+- Tactical matchup concerns (set pieces, press, pace, etc.)
+- Recent news-driven storylines from the provided headlines
 
-DO NOT reference final score or "after the match" facts.`
+DO NOT reference final score or "after the match" facts.` + reference
 	}
-	return `You are a football debate prompt generator for a mobile app where each debate gets ONE community vote: users swipe agree or disagree with a single proposition.
+	return `You are Fucci's elite football debate producer for a mobile app where each debate gets ONE community vote: users swipe agree or disagree with a single proposition.
 
 IMPORTANT: POST-MATCH — the match has finished. Use what happened; reference result and moments when useful.
+
+Quality bar: headlines must be bold, specific, and polarizing — tied to what actually happened in the match. Descriptions should fuel the argument with concrete moments, stats, or narratives. Study the reference corpus below for tone; keep debates anchored to THIS match, not generic season narratives.` + relevance + `
 
 The headline must read as a clear statement or question fans can answer YES or NO to. "Agree" and "disagree" must be direct opposites.
 
@@ -336,20 +384,20 @@ Respond with ONLY one JSON object (no markdown, no code fences, no extra text). 
     { "stance": "disagree", "title": "Short label for the NO / disagree side" }
   ],
   "comments": [
-    "Passionate fan comment supporting the agree side",
-    "Passionate fan comment supporting the disagree side",
-    "Wildcard / hot-take comment (still about this debate; fan voice not pundit voice)"
+    "Fucci's Take 1: passionate fan comment supporting the agree side",
+    "Fucci's Take 2: passionate fan comment supporting the disagree side",
+    "Fucci's Take 3: wildcard / hot-take comment (still about this debate; fan voice not pundit voice)"
   ]
 }
 
 Rules:
 - Exactly two cards: only "agree" and "disagree". No wildcard card.
 - Card objects: only "stance" and "title".
-- Exactly three "comments" strings for seeded replies.
+- Exactly three "comments" strings for pre-seeded "Fucci's Take" replies.
 - Comments: passionate fan energy, engaging, conversational; NOT polished analyst prose or heavy tactical jargon unless a fan would naturally say it.
 - PG-13 only.
 
-Good angles: turning points, calls, performances, blame, praise, narratives after the result.`
+Strong post-match angles: turning points, refereeing calls, individual performances, blame/praise, tactical switches, knockout consequences — always tied to events in THIS game.` + reference
 }
 
 func (pg *PromptGenerator) buildUserPrompt(matchData MatchData, promptType string) string {
@@ -369,6 +417,9 @@ func (pg *PromptGenerator) buildUserPrompt(matchData MatchData, promptType strin
 	}
 	if matchData.Season != "" {
 		prompt.WriteString(fmt.Sprintf("Season: %s\n", matchData.Season))
+	}
+	if matchData.Round != "" {
+		prompt.WriteString(fmt.Sprintf("Round/Stage: %s\n", matchData.Round))
 	}
 	prompt.WriteString("\n")
 
@@ -429,7 +480,7 @@ func (pg *PromptGenerator) buildUserPrompt(matchData MatchData, promptType strin
 	}
 
 	if len(matchData.NewsHeadlines) > 0 {
-		prompt.WriteString("NEWS HEADLINES:\n")
+		prompt.WriteString("NEWS HEADLINES (use these — anchor debates in recent match news when possible):\n")
 		for _, headline := range matchData.NewsHeadlines {
 			prompt.WriteString(fmt.Sprintf("- %s\n", headline))
 		}
@@ -456,7 +507,17 @@ func (pg *PromptGenerator) buildUserPrompt(matchData MatchData, promptType strin
 		prompt.WriteString("\n")
 	}
 
-	prompt.WriteString("Generate a compelling debate prompt based on this information. Return only valid JSON.")
+	prompt.WriteString("Generate a match-specific debate prompt from this data. ")
+	if len(matchData.NewsHeadlines) > 0 {
+		prompt.WriteString("At least one angle should clearly reflect a recent news headline above. ")
+	}
+	if matchData.HeadToHeadSummary != "" {
+		prompt.WriteString("Use head-to-head history where it sharpens the argument. ")
+	}
+	if matchData.Lineups != nil {
+		prompt.WriteString("Reference named players from the lineups when debating selections or matchups. ")
+	}
+	prompt.WriteString("Avoid generic 'who wins the showdown' framing. Return only valid JSON.")
 
 	return prompt.String()
 }
@@ -506,24 +567,30 @@ const maxTokensForDebateSet = 2800
 // buildSystemPromptForSet returns a system prompt that asks for an array of N debate prompts.
 func (pg *PromptGenerator) buildSystemPromptForSet(promptType string, count int) string {
 	phase := "PRE-MATCH"
-	phaseNote := "The match has NOT happened yet. Focus on predictions, pressure, expectations, possible outcomes, tactical storylines, player narratives, and what is at stake."
+	phaseNote := "The match has NOT happened yet. Focus on this fixture: lineup calls, player matchups, H2H, upset potential, knockout stakes, and news-driven storylines — not generic season-long contender hype."
 	if promptType == "post_match" {
 		phase = "POST-MATCH"
-		phaseNote = "The match has already happened. Focus on what actually happened, who delivered, who failed, tactical consequences, emotional fallout, blame, praise, and legacy-defining takeaways."
+		phaseNote = "The match has already happened. Focus on what actually happened in this game: turning points, individual performances, calls, tactical choices, and knockout consequences."
 	}
 
-	return fmt.Sprintf(`You are an elite football debate producer for a mobile app: ONE vote per debate (agree vs disagree on a single proposition).
+	reference := ReferenceDebatesPromptSection()
+	relevance := debateRelevanceGuidelines(promptType)
+	return fmt.Sprintf(`You are Fucci's elite football debate producer for a mobile app: ONE vote per debate (agree vs disagree on a single proposition).
 
 	IMPORTANT: This is a %s debate. %s
+%s
+	Quality bar: headlines must be bold, specific, and polarizing — the kind of take that stops a fan mid-scroll. Study the reference corpus below for tone; every debate must feel written for THIS match, round, and news cycle.
 
-	Each debate is binary: a headline fans can agree or disagree with, two stance labels (agree/disagree), and three seeded comments in a passionate FAN voice (not polished pundit copy; avoid analyst jargon unless a normal supporter would say it). Comments should feel like stands or group-chat energy: short, heated, believable, PG-13.
+	Each debate is binary: a headline fans can agree or disagree with, two stance labels (agree/disagree), and three pre-seeded "Fucci's Take" comments in a passionate FAN voice (not polished pundit copy; avoid analyst jargon unless a normal supporter would say it). Comments should feel like stands or group-chat energy: short, heated, believable, PG-13.
 
 	JSON rules for EVERY object in the array:
 	- Exactly two cards: { "stance": "agree", "title": "..." } and { "stance": "disagree", "title": "..." } only. No wildcard card. No "description" on cards.
-	- "comments" must be an array of exactly three strings: (1) backs agree, (2) backs disagree, (3) wildcard/hot-take still tied to this debate.
+	- "comments" must be an array of exactly three strings: (1) Fucci's Take backing agree, (2) Fucci's Take backing disagree, (3) wildcard/hot-take still tied to this debate.
 	- Headline frames an agree/disagree split; description adds match-specific stakes.
+	- When NEWS HEADLINES appear in the user message, at least one debate in the set must spring directly from a headline.
+	- Prefer named players, selection drama, H2H angles, and upset/concern takes over generic "who wins" showdown titles.
 
-	Keep debates distinct: different angles, emotions, and stakes; no recycled headlines.
+	Keep debates distinct: different angles, emotions, and stakes; no recycled headlines; no lazy "Team A vs Team B" packaging.
 
 	Respond with ONLY a JSON array of exactly %d objects (no markdown, no code fences, no extra text).
 
@@ -535,10 +602,10 @@ func (pg *PromptGenerator) buildSystemPromptForSet(promptType string, count int)
 		{ "stance": "agree", "title": "Short YES-side label" },
 		{ "stance": "disagree", "title": "Short NO-side label" }
 	],
-	"comments": ["fan comment pro-agree", "fan comment pro-disagree", "fan wildcard take"]
+	"comments": ["Fucci's Take pro-agree", "Fucci's Take pro-disagree", "Fucci's Take wildcard"]
 	}
 
-	Return only the JSON array.`, phase, phaseNote, count)
+	Return only the JSON array.%s`, phase, phaseNote, relevance, count, reference)
 }
 
 // GenerateDebateSetPrompt performs one AI call and returns multiple debate prompts (e.g. 3) for the given type.

--- a/services/api/internal/ai/prompt_generator.go
+++ b/services/api/internal/ai/prompt_generator.go
@@ -345,9 +345,9 @@ Respond with ONLY one JSON object (no markdown, no code fences, no extra text). 
     { "stance": "disagree", "title": "Short label for the NO / disagree side" }
   ],
   "comments": [
-    "Fucci's Take 1: passionate fan voice backing the agree side",
-    "Fucci's Take 2: passionate fan voice backing the disagree side",
-    "Fucci's Take 3: spicy wildcard / hot-take that still fits the debate"
+    "passionate fan voice backing the agree side",
+    "passionate fan voice backing the disagree side",
+    "spicy wildcard / hot-take that still fits the debate"
   ]
 }
 
@@ -384,9 +384,9 @@ Respond with ONLY one JSON object (no markdown, no code fences, no extra text). 
     { "stance": "disagree", "title": "Short label for the NO / disagree side" }
   ],
   "comments": [
-    "Fucci's Take 1: passionate fan comment supporting the agree side",
-    "Fucci's Take 2: passionate fan comment supporting the disagree side",
-    "Fucci's Take 3: wildcard / hot-take comment (still about this debate; fan voice not pundit voice)"
+    "passionate fan comment supporting the agree side",
+    "passionate fan comment supporting the disagree side",
+    "wildcard / hot-take comment (still about this debate; fan voice not pundit voice)"
   ]
 }
 
@@ -585,7 +585,7 @@ func (pg *PromptGenerator) buildSystemPromptForSet(promptType string, count int)
 
 	JSON rules for EVERY object in the array:
 	- Exactly two cards: { "stance": "agree", "title": "..." } and { "stance": "disagree", "title": "..." } only. No wildcard card. No "description" on cards.
-	- "comments" must be an array of exactly three strings: (1) Fucci's Take backing agree, (2) Fucci's Take backing disagree, (3) wildcard/hot-take still tied to this debate.
+	- "comments" must be an array of exactly three strings: (1) fan comment backing agree, (2) fan comment backing disagree, (3) wildcard/hot-take still tied to this debate.
 	- Headline frames an agree/disagree split; description adds match-specific stakes.
 	- When NEWS HEADLINES appear in the user message, at least one debate in the set must spring directly from a headline.
 	- Prefer named players, selection drama, H2H angles, and upset/concern takes over generic "who wins" showdown titles.
@@ -602,7 +602,7 @@ func (pg *PromptGenerator) buildSystemPromptForSet(promptType string, count int)
 		{ "stance": "agree", "title": "Short YES-side label" },
 		{ "stance": "disagree", "title": "Short NO-side label" }
 	],
-	"comments": ["Fucci's Take pro-agree", "Fucci's Take pro-disagree", "Fucci's Take wildcard"]
+	"comments": ["fan comment backing agree", "fan comment backing disagree", "wildcard hot-take fan comment"]
 	}
 
 	Return only the JSON array.%s`, phase, phaseNote, relevance, count, reference)

--- a/services/api/internal/ai/prompt_generator_test.go
+++ b/services/api/internal/ai/prompt_generator_test.go
@@ -77,3 +77,60 @@ func TestExtractJSONFromContent_StripsMarkdownFences(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildUserPrompt_IncludesRoundAndNewsGuidance(t *testing.T) {
+	pg := &PromptGenerator{}
+	matchData := MatchData{
+		MatchID:       "100",
+		HomeTeam:      "Brazil",
+		AwayTeam:      "Japan",
+		Date:          "2026-06-28T19:00:00Z",
+		Status:        "NS",
+		Round:         "Round of 32",
+		NewsHeadlines: []string{"Endrick set to start for Brazil in knockout clash"},
+	}
+	prompt := pg.buildUserPrompt(matchData, "pre_match")
+	if !strings.Contains(prompt, "Round/Stage: Round of 32") {
+		t.Error("prompt should contain round/stage")
+	}
+	if !strings.Contains(prompt, "NEWS HEADLINES (use these") {
+		t.Error("prompt should emphasize news headlines")
+	}
+	if !strings.Contains(prompt, "Endrick set to start") {
+		t.Error("prompt should include news headline text")
+	}
+	if !strings.Contains(prompt, "Avoid generic 'who wins the showdown'") {
+		t.Error("prompt should discourage generic showdown framing")
+	}
+}
+
+func TestBuildSystemPrompt_IncludesRelevanceGuidelines(t *testing.T) {
+	pg := &PromptGenerator{}
+	pre := pg.buildSystemPrompt("pre_match")
+	post := pg.buildSystemPrompt("post_match")
+	for _, prompt := range []string{pre, post} {
+		if !strings.Contains(prompt, "MATCH-SPECIFIC RELEVANCE") {
+			t.Error("system prompt should include match-specific relevance guidelines")
+		}
+		if !strings.Contains(prompt, "NEWS HEADLINES") {
+			t.Error("system prompt should instruct use of news headlines")
+		}
+		if !strings.Contains(prompt, "Classic giants or rising stars") {
+			t.Error("system prompt should ban lazy generic framing examples")
+		}
+	}
+	if !strings.Contains(pre, "knockout rounds") {
+		t.Error("pre-match prompt should mention knockout round guidance")
+	}
+}
+
+func TestBuildSystemPromptForSet_IncludesRelevanceGuidelines(t *testing.T) {
+	pg := &PromptGenerator{}
+	prompt := pg.buildSystemPromptForSet("pre_match", 3)
+	if !strings.Contains(prompt, "MATCH-SPECIFIC RELEVANCE") {
+		t.Error("set system prompt should include relevance guidelines")
+	}
+	if !strings.Contains(prompt, "at least one debate in the set must spring directly from a headline") {
+		t.Error("set system prompt should require headline-driven debate in set")
+	}
+}

--- a/services/api/internal/ai/reference_debates.go
+++ b/services/api/internal/ai/reference_debates.go
@@ -1,0 +1,90 @@
+package ai
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// ReferenceDebate is a curated World Cup debate used to steer AI generation quality.
+type ReferenceDebate struct {
+	ID          int      `json:"id"`
+	Headline    string   `json:"headline"`
+	Description string   `json:"description"`
+	Comments    []string `json:"comments"` // three "Fucci's Take" seeded comments
+}
+
+//go:embed reference_debates.json
+var referenceDebatesJSON []byte
+
+var (
+	referenceDebatesOnce sync.Once
+	referenceDebates     []ReferenceDebate
+	referenceDebatesErr  error
+)
+
+// LoadReferenceDebates returns the embedded FIFA World Cup reference debate corpus.
+func LoadReferenceDebates() ([]ReferenceDebate, error) {
+	referenceDebatesOnce.Do(func() {
+		referenceDebatesErr = json.Unmarshal(referenceDebatesJSON, &referenceDebates)
+	})
+	return referenceDebates, referenceDebatesErr
+}
+
+// ReferenceDebateCount returns how many reference debates are embedded.
+func ReferenceDebateCount() int {
+	debates, err := LoadReferenceDebates()
+	if err != nil {
+		return 0
+	}
+	return len(debates)
+}
+
+// ReferenceDebatesPromptSection returns a system-prompt appendix with style examples
+// from the embedded corpus (full examples + headline index for tone matching).
+func ReferenceDebatesPromptSection() string {
+	debates, err := LoadReferenceDebates()
+	if err != nil || len(debates) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n\nREFERENCE CORPUS — FIFA World Cup debate style guide (1966–2026):\n")
+	b.WriteString("Match this tone: bold polarizing headlines, stakes-driven descriptions, and seeded \"Fucci's Take\" comments that sound like passionate fans in the stands — not TV pundits.\n")
+	b.WriteString("Headlines should be plain-language yes/no propositions. Descriptions should cite real controversy, records, or narratives.\n")
+	b.WriteString("Each debate needs exactly three seeded comments labeled \"Fucci's Take\" in the app:\n")
+	b.WriteString("  (1) backs the agree side with heat and conviction\n")
+	b.WriteString("  (2) backs the disagree side with a sharp counter\n")
+	b.WriteString("  (3) a wildcard/hot-take angle that still fits the debate\n")
+	b.WriteString("Comments: short, conversational, PG-13, emotionally charged — never analyst jargon unless a normal fan would say it.\n\n")
+
+	exampleCount := 5
+	if len(debates) < exampleCount {
+		exampleCount = len(debates)
+	}
+	b.WriteString("FULL EXAMPLES (headline + description + three Fucci's Takes):\n")
+	for i := 0; i < exampleCount; i++ {
+		appendReferenceDebateExample(&b, debates[i])
+	}
+
+	b.WriteString("\nALL REFERENCE HEADLINES (match this quality and specificity when generating new debates):\n")
+	for _, d := range debates {
+		b.WriteString(fmt.Sprintf("- [%d] %s\n", d.ID, d.Headline))
+	}
+
+	return b.String()
+}
+
+func appendReferenceDebateExample(b *strings.Builder, d ReferenceDebate) {
+	b.WriteString(fmt.Sprintf("\nExample #%d:\n", d.ID))
+	b.WriteString(fmt.Sprintf("Headline: %s\n", d.Headline))
+	b.WriteString(fmt.Sprintf("Description: %s\n", d.Description))
+	for i, c := range d.Comments {
+		if strings.TrimSpace(c) == "" {
+			continue
+		}
+		b.WriteString(fmt.Sprintf("Fucci's Take %d: %s\n", i+1, c))
+	}
+}

--- a/services/api/internal/ai/reference_debates.go
+++ b/services/api/internal/ai/reference_debates.go
@@ -53,7 +53,7 @@ func ReferenceDebatesPromptSection() string {
 	var b strings.Builder
 	b.WriteString("\n\nREFERENCE CORPUS — FIFA World Cup debate style guide (1966–2026):\n")
 	b.WriteString("Match this tone: bold polarizing headlines, stakes-driven descriptions, and seeded \"Fucci's Take\" comments that sound like passionate fans in the stands — not TV pundits.\n")
-	b.WriteString("Headlines should be plain-language yes/no propositions. Descriptions should cite real controversy, records, or narratives.\n")
+	b.WriteString("Headlines should be plain-language yes/no propositions. Descriptions should draw on notable controversy, records, or narratives.\n")
 	b.WriteString("Each debate needs exactly three seeded comments labeled \"Fucci's Take\" in the app:\n")
 	b.WriteString("  (1) backs the agree side with heat and conviction\n")
 	b.WriteString("  (2) backs the disagree side with a sharp counter\n")
@@ -70,8 +70,12 @@ func ReferenceDebatesPromptSection() string {
 	}
 
 	b.WriteString("\nALL REFERENCE HEADLINES (match this quality and specificity when generating new debates):\n")
-	for _, d := range debates {
-		b.WriteString(fmt.Sprintf("- [%d] %s\n", d.ID, d.Headline))
+	headlineCount := 25
+	if len(debates) < headlineCount {
+		headlineCount = len(debates)
+	}
+	for i := 0; i < headlineCount; i++ {
+		b.WriteString(fmt.Sprintf("- [%d] %s\n", debates[i].ID, debates[i].Headline))
 	}
 
 	return b.String()

--- a/services/api/internal/ai/reference_debates.json
+++ b/services/api/internal/ai/reference_debates.json
@@ -384,7 +384,7 @@
     "headline": "Ronaldo scored a hat-trick against Spain in the group stage and then disappeared from the tournament. Is that the most wasteful great performance in World Cup history?",
     "description": "Ronaldo's three goals against Spain — including a 90th-minute free kick — were extraordinary. Portugal then lost to Uruguay in the round of 16 with Ronaldo largely anonymous. One side says his group-stage performance alone was one of the greatest individual shows in tournament history. The other says a great player shows up when it actually matters — in the knockouts.",
     "comments": [
-      "The agree side is winning this argument and it's not close: Ronaldo scored a hat-trick against Spain in the group stage and then disappeared from the tournament. Is that the most wasteful great performance in World Cup history. The evidence is right there if you're willing to loo",
+      "The agree side is winning this argument and it's not close: Ronaldo scored a hat-trick against Spain in the group stage and then disappeared from the tournament. Is that the most wasteful great performance in World Cup history. The evidence is right there if you're willing to look.",
       "Everyone on the agree side is ignoring the obvious: Ronaldo's three goals against Spain — including a 90th-minute free kick — were...",
       "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
     ]
@@ -484,7 +484,7 @@
     "headline": "James Rodríguez won the Golden Boot in 2014 despite Colombia going out in the quarterfinals. Should the best individual at a World Cup always come from the winning team?",
     "description": "Rodríguez scored six goals including a contender for the greatest strike in tournament history. Colombia didn't make the final. One side says individual brilliance should be celebrated regardless of team outcome — the Golden Boot is for the scorer, not the winners. The other says tournament football is about teams, and crowning the best player from a losing nation sends the wrong message.",
     "comments": [
-      "The agree side is winning this argument and it's not close: James Rodríguez won the Golden Boot in 2014 despite Colombia going out in the quarterfinals. Should the best individual at a World Cup always come from the winning team. The evidence is right there if you're willing to l",
+      "The agree side is winning this argument and it's not close: James Rodríguez won the Golden Boot in 2014 despite Colombia going out in the quarterfinals. Should the best individual at a World Cup always come from the winning team. The evidence is right there if you're willing to look.",
       "Everyone on the agree side is ignoring the obvious: Rodríguez scored six goals including a contender for the greatest strike in...",
       "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
     ]

--- a/services/api/internal/ai/reference_debates.json
+++ b/services/api/internal/ai/reference_debates.json
@@ -1,0 +1,1002 @@
+[
+  {
+    "id": 1,
+    "headline": "Messi scored all five of Argentina's group-stage goals at 2026. Is the GOAT debate finally over — or does Ronaldo's longevity record make it closer than ever?",
+    "description": "Messi broke the all-time men's and women's World Cup scoring record in 2026, while Ronaldo became the first player to score at six different tournaments. Two records, two legends, same tournament. One side says Messi's dominance is untouchable. The other says Ronaldo's 20-year consistency across six World Cups is the greater achievement. Which record matters more?",
+    "comments": [
+      "Look, everyone sleeping on this — Messi scored all five of Argentina's group-stage goals at 2026. Is the GOAT debate finally over — or does Ronaldo's longevity record make it closer than ever. The evidence is right there if you're willing to look.",
+      "Hard pass. Messi broke the all-time men's and women's World Cup scoring record in 2026, while...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 2,
+    "headline": "Ronaldo started for Portugal at 41 and scored twice. Hero or burden — should he have been dropped for the good of the team?",
+    "description": "ESPN ran pieces questioning whether an overworked Ronaldo was hurting Portugal's fluidity, noting he had just 35 touches in a 0-0 draw and only two touches inside the penalty area. Supporters say his goals prove he still delivers. Critics say Portugal looked more fluid without him. Was Martínez too loyal, or was Ronaldo still worth it?",
+    "comments": [
+      "Hard agree. Ronaldo started for Portugal at 41 and scored twice. Hero or burden — should he have been dropped for the good of the team. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — ESPN ran pieces questioning whether an overworked Ronaldo was hurting Portugal's...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 3,
+    "headline": "The 48-team World Cup gave us Cape Verde's fairytale and 72 group-stage games. Was that trade-off worth it?",
+    "description": "Fox Sports argued the expansion needed a Cinderella story to justify itself — Cape Verde provided it, drawing all three group games against Spain, Uruguay, and Saudi Arabia. ESPN's Marcotti countered that 72 group-stage games is more than the entire 2022 tournament. More drama or more filler? You decide.",
+    "comments": [
+      "Say it louder — The 48-team World Cup gave us Cape Verde's fairytale and 72 group-stage games. Was that trade-off worth it. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Fox Sports argued the expansion needed a Cinderella story to justify itself — Cape...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 4,
+    "headline": "Final tickets hit $32,970. FIFA say it's market forces. Everyone else says it's greed. Who's right?",
+    "description": "The cheapest 2026 group-stage seat cost $100 — up from $11 at Qatar 2022. Final tickets tripled in price to nearly $33,000. New York and New Jersey attorneys general launched a formal investigation. FIFA defended the dynamic pricing model. Was this capitalism working as intended, or football pricing out the fans who built it?",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Final tickets hit $32,970. FIFA say it's market forces. Everyone else says it's greed. Who's right. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: The cheapest 2026 group-stage seat cost $100 — up from $11 at Qatar 2022. Final...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 5,
+    "headline": "Iran was at war with the USA during the 2026 World Cup and still played. Was that brave, reckless, or deeply wrong?",
+    "description": "The US and Iran were engaged in active conflict during the tournament. Iranian fans were banned from attending US-hosted matches. Trump reportedly asked FIFA to replace Iran with Italy. FIFA refused. One side says football must stay above politics. The other says hosting a wartime opponent is an insult to both nations.",
+    "comments": [
+      "This is the hill I'll die on — Iran was at war with the USA during the 2026 World Cup and still played. Was that brave, reckless, or deeply wrong. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think The US and Iran were engaged in active conflict during the tournament. Iranian fans...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 6,
+    "headline": "ICE agents were confirmed inside 2026 World Cup stadiums in the USA. Did that cross a line sport should never cross?",
+    "description": "DHS Secretary Mullin confirmed immigration enforcement agents were stationed at World Cup venues. Supporters say it was standard security. Critics say using a global sporting event as an immigration enforcement site turned stadiums into political weapons. Was it protection or intimidation?",
+    "comments": [
+      "Look, everyone sleeping on this — ICE agents were confirmed inside 2026 World Cup stadiums in the USA. Did that cross a line sport should never cross. The evidence is right there if you're willing to look.",
+      "Hard pass. DHS Secretary Mullin confirmed immigration enforcement agents were stationed at...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 7,
+    "headline": "BBC and ITV refused to air the 2026 World Cup halftime show. Were they defending football or being culturally arrogant?",
+    "description": "FIFA introduced a halftime entertainment show at the 2026 World Cup. The BBC and ITV refused to broadcast it, calling it an Americanisation of football. Supporters say it modernises the sport and grows the global audience. Critics say it's a gimmick that disrespects football's identity. Who's actually protecting the game here?",
+    "comments": [
+      "Hard agree. BBC and ITV refused to air the 2026 World Cup halftime show. Were they defending football or being culturally arrogant. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — FIFA introduced a halftime entertainment show at the 2026 World Cup. The BBC and ITV...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 8,
+    "headline": "The 2026 World Cup produced 7.8 million tonnes of CO₂ — double Qatar 2022. Should it even have been held across three countries?",
+    "description": "An independent carbon accounting study found the 2026 tournament's footprint was driven 87.8% by travel across three countries. FIFA pledged sustainability commitments while simultaneously sponsoring Saudi oil company Aramco. Is a three-nation World Cup environmentally indefensible, or is football too important to be restricted by carbon politics?",
+    "comments": [
+      "Say it louder — The 2026 World Cup produced 7.8 million tonnes of CO₂ — double Qatar 2022. Should it even have been held across three countries. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — An independent carbon accounting study found the 2026 tournament's footprint was...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 9,
+    "headline": "Infantino gave Trump the FIFA Peace Prize. Was that an act of pragmatism — or the moment FIFA officially stopped pretending to be independent?",
+    "description": "Infantino awarded Trump the inaugural FIFA Peace Prize in December 2025. UEFA representatives walked out of the FIFA Congress in protest. Infantino defended it, saying Trump's involvement made the 2026 World Cup possible. Was this smart political management or proof that FIFA's moral compass is broken?",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Infantino gave Trump the FIFA Peace Prize. Was that an act of pragmatism — or the moment FIFA officially stopped pretending to be independent. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: Infantino awarded Trump the inaugural FIFA Peace Prize in December 2025. UEFA...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 10,
+    "headline": "France went perfect in the 2026 group stage. Are they the greatest World Cup team of this generation — or perennial overperformers in the group stage who stumble when it matters?",
+    "description": "France finished 3 from 3 in the group stage and led ESPN's power rankings. Yet their 2022 run ended as runners-up and their 2010 and 2014 exits were disasters. One side says France are a generational force. The other says they consistently underperform in knockout football relative to their talent.",
+    "comments": [
+      "This is the hill I'll die on — France went perfect in the 2026 group stage. Are they the greatest World Cup team of this generation — or perennial overperformers in the group stage who stumble when it matters. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think France finished 3 from 3 in the group stage and led ESPN's power rankings. Yet their...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 11,
+    "headline": "Luka Modrić played his final World Cup in his 40s and was still Croatia's best player. Is he the most criminally underrated player in World Cup history?",
+    "description": "Fox Sports described Modrić as the master of dragging a team through a tournament, with spatial intelligence that defies age. Croatia reached the 2018 final and 2022 semifinal almost entirely on his back. Some call him the greatest midfielder to never lift the World Cup. Others say you can't be underrated if everyone knows how good you are.",
+    "comments": [
+      "Look, everyone sleeping on this — Luka Modrić played his final World Cup in his 40s and was still Croatia's best player. Is he the most criminally underrated player in World Cup history. The evidence is right there if you're willing to look.",
+      "Hard pass. Fox Sports described Modrić as the master of dragging a team through a tournament,...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 12,
+    "headline": "VAR disallowed a goal for a toe being offside at the 2026 World Cup. Is toenail offside the most embarrassing rule in football?",
+    "description": "ESPN's VAR review column covered multiple disputed toenail offside calls, noting FIFA uses the technology with zero tolerance, unlike the Premier League's 5cm buffer. One side says rules are rules — offside is offside by any margin. The other says disallowing goals where no goalscoring advantage was gained is destroying the sport.",
+    "comments": [
+      "Hard agree. VAR disallowed a goal for a toe being offside at the 2026 World Cup. Is toenail offside the most embarrassing rule in football. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — ESPN's VAR review column covered multiple disputed toenail offside calls, noting...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 13,
+    "headline": "The Somali referee denied a US visa made headline news. Was that FIFA's biggest off-pitch failure — or proof sport is powerless against politics?",
+    "description": "Omar Artan became the first Somali selected to officiate a World Cup, then was denied entry to the host country. Infantino called it \"unfortunate.\" Critics say FIFA should have guaranteed visa protection for all officials before awarding hosting rights to a country with restrictive immigration policies. Who failed Artan?",
+    "comments": [
+      "Say it louder — The Somali referee denied a US visa made headline news. Was that FIFA's biggest off-pitch failure — or proof sport is powerless against politics. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Omar Artan became the first Somali selected to officiate a World Cup, then was...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 14,
+    "headline": "Should football ever be used as a platform for political protest, or should players keep their opinions off the pitch?",
+    "description": "From rainbow armband bans to political goal celebrations at the 2026 World Cup — including Mohammad Mohebi's gun-firing gesture and Jude Bellingham covering his mouth mid-game — the tournament was full of players pushing and testing political limits. Is the World Cup a legitimate platform for protest, or should politics stay out of sport entirely?",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Should football ever be used as a platform for political protest, or should players keep their opinions off the pitch. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: From rainbow armband bans to political goal celebrations at the 2026 World Cup —...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 15,
+    "headline": "Hydration breaks were introduced to protect players in the heat. Or did they just hand coaches an illegal extra tactical timeout?",
+    "description": "ESPN data showed 170 shots taken in the period between the hydration break and halftime at the 2026 World Cup — versus only 115 before it. Critics argue the breaks are being exploited as mid-half tactical instructions. Supporters say player welfare in extreme heat is non-negotiable. Who's right?",
+    "comments": [
+      "This is the hill I'll die on — Hydration breaks were introduced to protect players in the heat. Or did they just hand coaches an illegal extra tactical timeout. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think ESPN data showed 170 shots taken in the period between the hydration break and...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 16,
+    "headline": "Haaland scored four World Cup goals in two games. Is he already the most complete striker on the planet — or does he disappear in tight knockout games?",
+    "description": "Norway's Haaland matched Mbappé's goal tally in the group stage and trailed only Messi in the Golden Boot race. Supporters say his numbers at club and international level are historic. Critics say his performances against elite defensive setups in knockout football still need to be proven. Is he the real deal at the biggest level?",
+    "comments": [
+      "Look, everyone sleeping on this — Haaland scored four World Cup goals in two games. Is he already the most complete striker on the planet — or does he disappear in tight knockout games. The evidence is right there if you're willing to look.",
+      "Hard pass. Norway's Haaland matched Mbappé's goal tally in the group stage and trailed only...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 17,
+    "headline": "Argentina's squad in 2026 was nearly identical to their 2022 World Cup winning side. Is that loyalty or stubbornness?",
+    "description": "ESPN noted defending champions who fail to refresh have historically collapsed — Spain 2014, Germany 2018. Scaloni kept faith with essentially the same squad. One side says why change a winning formula. The other says football moves fast and an aging squad that doesn't evolve gets found out. Was Scaloni's loyalty a strength or a risk?",
+    "comments": [
+      "Hard agree. Argentina's squad in 2026 was nearly identical to their 2022 World Cup winning side. Is that loyalty or stubbornness. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — ESPN noted defending champions who fail to refresh have historically collapsed —...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 18,
+    "headline": "Messi is 38 and breaking scoring records. Should he retire immediately after this tournament, or keep going for as long as he's contributing?",
+    "description": "Messi broke the all-time World Cup scoring record and led Argentina's group stage as the tournament's top scorer. Some say his legacy is untouchable — retire at the peak and let the image stay perfect. Others say if he's still the best player at the tournament at 38, you don't retire greatness — you let it run.",
+    "comments": [
+      "Say it louder — Messi is 38 and breaking scoring records. Should he retire immediately after this tournament, or keep going for as long as he's contributing. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Messi broke the all-time World Cup scoring record and led Argentina's group stage as...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 19,
+    "headline": "France are ranked #1. Argentina are #2. If they meet in the knockouts, who wins — and does it settle who truly owns 2022?",
+    "description": "ESPN and Fox Sports both flagged a potential quarterfinal clash between Messi and Mbappé as the defining matchup of the 2026 tournament. France were runners-up to Argentina in 2022. One side says Argentina are the defending champions and Messi is in historic form. The other says France are deeper, faster, and hungrier for revenge.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: France are ranked #1. Argentina are #2. If they meet in the knockouts, who wins — and does it settle who truly owns 2022. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: ESPN and Fox Sports both flagged a potential quarterfinal clash between Messi and...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 20,
+    "headline": "Co-hosting across USA, Canada, and Mexico created genuine logistical chaos. Was it worth it — or did the tournament feel more like three separate events?",
+    "description": "Teams faced different climates, time zones, travel schedules, and three separate government bureaucracies. Some delegations experienced major pre-match disruptions. One side says the scale and reach of the tournament was unprecedented and brilliant. The other says the sport got lost in the logistics.",
+    "comments": [
+      "This is the hill I'll die on — Co-hosting across USA, Canada, and Mexico created genuine logistical chaos. Was it worth it — or did the tournament feel more like three separate events. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think Teams faced different climates, time zones, travel schedules, and three separate...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 21,
+    "headline": "Qatar was awarded the World Cup through bribery, built stadiums on migrant worker deaths, and criminalises homosexuality. Should the tournament have been stripped from them?",
+    "description": "A 2024 FIFA-commissioned independent review confirmed severe human rights impacts occurred in Qatar from 2010 through 2022. Former FIFA president Sepp Blatter twice said the decision was wrong. Others argue the tournament happened, reforms followed, and retroactively stripping it serves no one. Should FIFA have acted?",
+    "comments": [
+      "Look, everyone sleeping on this — Qatar was awarded the World Cup through bribery, built stadiums on migrant worker deaths, and criminalises homosexuality. Should the tournament have been stripped from them. The evidence is right there if you're willing to look.",
+      "Hard pass. A 2024 FIFA-commissioned independent review confirmed severe human rights impacts...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 22,
+    "headline": "Thousands of migrant workers died building Qatar's World Cup stadiums. Is FIFA morally complicit — or is this Qatar's responsibility alone?",
+    "description": "Human rights groups reported thousands of deaths linked to construction of World Cup infrastructure. FIFA denied direct accountability. A 2024 review said FIFA \"has a responsibility\" toward affected workers and families. One side demands FIFA establish a compensation fund. The other says FIFA cannot be held responsible for the laws of a sovereign nation.",
+    "comments": [
+      "Hard agree. Thousands of migrant workers died building Qatar's World Cup stadiums. Is FIFA morally complicit — or is this Qatar's responsibility alone. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Human rights groups reported thousands of deaths linked to construction of World Cup...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 23,
+    "headline": "FIFA banned rainbow armbands hours before kick-off at Qatar 2022, after months of saying they were allowed. Was that the most cowardly u-turn in football history?",
+    "description": "European captains had committed months in advance to wearing the OneLove armband. Kit violations typically incur a fine, which teams were willing to pay. FIFA reversed course on the morning of the first game, threatening yellow cards instead. One side says FIFA caved to the host nation. The other says they were right to respect Qatari law on Qatari soil.",
+    "comments": [
+      "Say it louder — FIFA banned rainbow armbands hours before kick-off at Qatar 2022, after months of saying they were allowed. Was that the most cowardly u-turn in football history. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — European captains had committed months in advance to wearing the OneLove armband....",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 24,
+    "headline": "Argentina vs Netherlands in 2022 devolved into a brawl. Was it the referee's fault, or just the most intense football ever played?",
+    "description": "The quarterfinal in Lusail featured mass confrontations, reckless tackles, physical altercations, and verbal spats throughout. Some blame the referee for losing control early. Others say this was two passionate footballing nations at their absolute limits — exactly what the World Cup should produce. Was it a disgrace or a spectacle?",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Argentina vs Netherlands in 2022 devolved into a brawl. Was it the referee's fault, or just the most intense football ever played. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: The quarterfinal in Lusail featured mass confrontations, reckless tackles, physical...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 25,
+    "headline": "Japan's winning goal against Spain clearly looked out of play. VAR said it was in. Who do you believe — your eyes or the technology?",
+    "description": "A single camera angle confirmed the ball had not fully crossed the byline. Every other angle suggested it had. VAR sided with the technology. Millions of fans disagreed with their own eyes. One side says technology exists for exactly this purpose — trust it. The other says if the best camera angles available make the call look wrong, the call is wrong.",
+    "comments": [
+      "This is the hill I'll die on — Japan's winning goal against Spain clearly looked out of play. VAR said it was in. Who do you believe — your eyes or the technology. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think A single camera angle confirmed the ball had not fully crossed the byline. Every...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 26,
+    "headline": "Japan killed the game against Poland to qualify on fair play. Brilliant game management or a disgrace to football?",
+    "description": "Japan spent the final 10 minutes of a group game passing backwards, knowing the score elsewhere made fair play their route through. They became the first team ever to advance via yellow card count. One side says it was tactically ruthless and within the rules. The other says watching a team deliberately kill a football match is everything that's wrong with modern football.",
+    "comments": [
+      "Look, everyone sleeping on this — Japan killed the game against Poland to qualify on fair play. Brilliant game management or a disgrace to football. The evidence is right there if you're willing to look.",
+      "Hard pass. Japan spent the final 10 minutes of a group game passing backwards, knowing the...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 27,
+    "headline": "Morocco reached the World Cup semifinal in 2022, eliminating Belgium, Spain, and Portugal. Is it the greatest achievement in African football history — or just the beginning?",
+    "description": "Morocco became the first African nation to reach a World Cup semifinal. Their defensive organisation and emotional atmosphere were extraordinary. Some say it's the apex of African football history. Others say it should be seen not as an achievement to celebrate but as a baseline — Africa should expect to be in semifinals.",
+    "comments": [
+      "Hard agree. Morocco reached the World Cup semifinal in 2022, eliminating Belgium, Spain, and Portugal. Is it the greatest achievement in African football history — or just the beginning. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Morocco became the first African nation to reach a World Cup semifinal. Their...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 28,
+    "headline": "Messi finally won the World Cup in 2022. Did that single trophy make him indisputably greater than Maradona — or does Maradona's 1986 solo effort still trump everything?",
+    "description": "The case for Messi: six Ballon d'Ors, a World Cup, the greatest final in history. The case for Maradona: the 1986 tournament was essentially won by one man alone, across a squad of average players. Trophies can be won with great teams. Maradona won one almost entirely by himself. Which argument holds up?",
+    "comments": [
+      "Say it louder — Messi finally won the World Cup in 2022. Did that single trophy make him indisputably greater than Maradona — or does Maradona's 1986 solo effort still trump everything. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — The case for Messi: six Ballon d'Ors, a World Cup, the greatest final in history....",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 29,
+    "headline": "The 2022 World Cup final — Messi vs Mbappé, 3-3 after extra time, penalties — was it the greatest football match ever played?",
+    "description": "Argentina vs France had everything: a dominant first half, a stunning three-minute comeback, two iconic players at their peak, and a penalty shootout. Over 1.5 billion people watched. One side says no final will ever come close to matching it. The other says the 1970 final and other classics deserve the crown. Is 2022 the greatest?",
+    "comments": [
+      "The agree side is winning this argument and it's not close: The 2022 World Cup final — Messi vs Mbappé, 3-3 after extra time, penalties — was it the greatest football match ever played. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: Argentina vs France had everything: a dominant first half, a stunning three-minute...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 30,
+    "headline": "Qatar used the World Cup to sportswash its global reputation. Did it work — and should sport ever be used this way?",
+    "description": "Qatar's investment in global sport — including PSG, the World Cup bid, and the 2022 tournament itself — was widely described as a calculated attempt to improve its international image. Some argue the spotlight brought genuine reforms. Others say the deaths, the armband ban, and the criminalisation of LGBTQ+ fans prove nothing changed. Did the sportswash succeed?",
+    "comments": [
+      "This is the hill I'll die on — Qatar used the World Cup to sportswash its global reputation. Did it work — and should sport ever be used this way. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think Qatar's investment in global sport — including PSG, the World Cup bid, and the 2022...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 31,
+    "headline": "Infantino opened Qatar 2022 by likening himself to a migrant worker and a gay man. Was it the most tone-deaf speech by a sporting leader in history?",
+    "description": "Infantino's opening remarks — in which he said he understood the experience of being gay, being a foreigner, and being discriminated against because of his red hair — drew immediate and near-universal ridicule. Supporters say he was trying to bridge cultural divides. Critics say it was grotesque narcissism in the context of workers who had died building the stadiums.",
+    "comments": [
+      "Look, everyone sleeping on this — Infantino opened Qatar 2022 by likening himself to a migrant worker and a gay man. Was it the most tone-deaf speech by a sporting leader in history. The evidence is right there if you're willing to look.",
+      "Hard pass. Infantino's opening remarks — in which he said he understood the experience of being...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 32,
+    "headline": "Lamine Yamal, Jude Bellingham, and Pedri were all at or around 2022. Is this the most exciting generation of young players football has ever produced?",
+    "description": "A generation of teenagers and early-20s talent — Yamal scoring at his hometown stadium, Bellingham thriving on the biggest stages, Pedri controlling games with veteran composure — has arrived simultaneously. One side says no generation in football has had this level of talent emerge at once. The other says every era says that about itself.",
+    "comments": [
+      "Hard agree. Lamine Yamal, Jude Bellingham, and Pedri were all at or around 2022. Is this the most exciting generation of young players football has ever produced. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — A generation of teenagers and early-20s talent — Yamal scoring at his hometown...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 33,
+    "headline": "Moving the World Cup to winter wrecked every domestic league in the world. Was it worth it for player welfare in Qatar's heat?",
+    "description": "Every major football league — Premier League, La Liga, Bundesliga, Serie A, Ligue 1 — was forced to pause mid-season for the Qatar World Cup. Fox's US broadcast deal was signed for a summer tournament. One side says player safety in extreme heat was non-negotiable. The other says FIFA sacrificed the entire global football calendar to protect the commercial interests of one host.",
+    "comments": [
+      "Say it louder — Moving the World Cup to winter wrecked every domestic league in the world. Was it worth it for player welfare in Qatar's heat. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Every major football league — Premier League, La Liga, Bundesliga, Serie A, Ligue 1...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 34,
+    "headline": "Awarding the 2034 World Cup to Saudi Arabia shows FIFA learned nothing from Qatar. Agree or disagree?",
+    "description": "The 2034 World Cup was given to Saudi Arabia, drawing immediate human rights comparisons with the Qatar process. Supporters say engagement is better than exclusion and that Saudi Arabia, like Qatar, will be forced into scrutiny and reform. Critics say FIFA is simply repeating a corrupt pattern for money. Has football given up on ethics entirely?",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Awarding the 2034 World Cup to Saudi Arabia shows FIFA learned nothing from Qatar. Agree or disagree. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: The 2034 World Cup was given to Saudi Arabia, drawing immediate human rights...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 35,
+    "headline": "France entered Qatar 2022 as defending champions missing key players through injury. Did they actually outperform expectations by reaching the final — or underperform by losing it?",
+    "description": "Benzema withdrew pre-tournament, Pogba and Kante were long-term absentees. France still reached the final and led 3-2 in the 89th minute. One side says reaching the final with that injury list was extraordinary. The other says a team with France's depth should not have conceded three goals in 10 minutes of a World Cup final.",
+    "comments": [
+      "This is the hill I'll die on — France entered Qatar 2022 as defending champions missing key players through injury. Did they actually outperform expectations by reaching the final — or underperform by losing it. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think Benzema withdrew pre-tournament, Pogba and Kante were long-term absentees. France...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 36,
+    "headline": "Russia hosted the 2018 World Cup while occupying Crimea and funding disinformation campaigns. Should FIFA have stripped them of the tournament?",
+    "description": "FIFA awarded Russia the 2018 hosting rights before the annexation of Crimea. By the time the tournament was held, pressure to relocate had been mounting for years. One side says stripping a host punishes fans for their government's actions. The other says FIFA sending the world's biggest tournament to Russia was a political endorsement it had no right to make.",
+    "comments": [
+      "Look, everyone sleeping on this — Russia hosted the 2018 World Cup while occupying Crimea and funding disinformation campaigns. Should FIFA have stripped them of the tournament. The evidence is right there if you're willing to look.",
+      "Hard pass. FIFA awarded Russia the 2018 hosting rights before the annexation of Crimea. By the...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 37,
+    "headline": "VAR was introduced at the 2018 World Cup and immediately produced a record number of penalties. Did it fix football or break it?",
+    "description": "The 2018 World Cup was the first to use VAR, generating more penalties than any previous tournament. Overturned decisions changed multiple match outcomes. One side says VAR removed clear injustice from the game. The other says the technology created new controversies, slowed the game down, and made football feel clinical and joyless.",
+    "comments": [
+      "Hard agree. VAR was introduced at the 2018 World Cup and immediately produced a record number of penalties. Did it fix football or break it. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — The 2018 World Cup was the first to use VAR, generating more penalties than any...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 38,
+    "headline": "France won the 2018 World Cup playing ugly, defensive counter-attacking football. Do they deserve to be called champions?",
+    "description": "France scored 12 goals across the tournament but played conservatively, relied heavily on set pieces, and sat deep against most opponents. Griezmann averaged fewer than one shot per game from open play. One side says winning is winning — no one cares how you do it. The other says the greatest footballing nation on earth should not win a World Cup by parking the bus.",
+    "comments": [
+      "Say it louder — France won the 2018 World Cup playing ugly, defensive counter-attacking football. Do they deserve to be called champions. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — France scored 12 goals across the tournament but played conservatively, relied...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 39,
+    "headline": "Ronaldo scored a hat-trick against Spain in the group stage and then disappeared from the tournament. Is that the most wasteful great performance in World Cup history?",
+    "description": "Ronaldo's three goals against Spain — including a 90th-minute free kick — were extraordinary. Portugal then lost to Uruguay in the round of 16 with Ronaldo largely anonymous. One side says his group-stage performance alone was one of the greatest individual shows in tournament history. The other says a great player shows up when it actually matters — in the knockouts.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Ronaldo scored a hat-trick against Spain in the group stage and then disappeared from the tournament. Is that the most wasteful great performance in World Cup history. The evidence is right there if you're willing to loo",
+      "Everyone on the agree side is ignoring the obvious: Ronaldo's three goals against Spain — including a 90th-minute free kick — were...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 40,
+    "headline": "Germany were eliminated in the group stage as defending champions in 2018. Was it a generation dying or a catastrophic managerial failure?",
+    "description": "Germany failed to get out of the group in 2018 — their first group-stage exit since 1938. Löw kept faith with the ageing 2014 core and was tactically outmanoeuvred. One side says this was an inevitable generational decline. The other says Löw's stubbornness — refusing to drop Mueller, Hummels, and Boateng — was managerial negligence at the highest level.",
+    "comments": [
+      "This is the hill I'll die on — Germany were eliminated in the group stage as defending champions in 2018. Was it a generation dying or a catastrophic managerial failure. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think Germany failed to get out of the group in 2018 — their first group-stage exit since...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 41,
+    "headline": "Croatia reached the 2018 World Cup final with a squad built around one genius. Was it the greatest overachievement in the tournament's history?",
+    "description": "Croatia — a nation of four million — went the distance in 2018, playing extra time in three consecutive knockout games. Some say it's the most remarkable team performance in World Cup history. Others say the draw was kind and Modrić's individual genius does not make it an overachievement if you have the world's best midfielder.",
+    "comments": [
+      "Look, everyone sleeping on this — Croatia reached the 2018 World Cup final with a squad built around one genius. Was it the greatest overachievement in the tournament's history. The evidence is right there if you're willing to look.",
+      "Hard pass. Croatia — a nation of four million — went the distance in 2018, playing extra time...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 42,
+    "headline": "Belgium had De Bruyne, Hazard, Lukaku, Courtois, and Kompany — and never won a major trophy. Is it the greatest generation to achieve nothing?",
+    "description": "Belgium reached the 2018 World Cup semifinal with one of the most talented squads ever assembled. They lost to France and crashed out. They never won a major trophy. One side says the golden generation was fatally unlucky with timing. The other says you can't call it a golden generation if it yields nothing — talent without trophies is just potential.",
+    "comments": [
+      "Hard agree. Belgium had De Bruyne, Hazard, Lukaku, Courtois, and Kompany — and never won a major trophy. Is it the greatest generation to achieve nothing. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Belgium reached the 2018 World Cup semifinal with one of the most talented squads...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 43,
+    "headline": "Neymar's diving at the 2018 World Cup became a global meme. Should FIFA have retrospectively punished him — or is simulation just accepted gamesmanship?",
+    "description": "Neymar spent a combined four minutes on the ground during the group stage and was clocked rolling 20 metres after minimal contact. FIFA took no action. One side says simulation is cheating and should carry automatic retrospective bans. The other says every player in the modern game uses the floor as a tactical tool and Neymar was simply better at it than most.",
+    "comments": [
+      "Say it louder — Neymar's diving at the 2018 World Cup became a global meme. Should FIFA have retrospectively punished him — or is simulation just accepted gamesmanship. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Neymar spent a combined four minutes on the ground during the group stage and was...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 44,
+    "headline": "Messi was invisible in the 2018 knockouts. Before he won the World Cup in 2022, was he a fraud at international level — or just let down by the team around him?",
+    "description": "Argentina were eliminated in the round of 16 by France in 2018. Messi did not score from open play in the knockout rounds. ESPN ran pieces asking whether Messi was a club player who disappeared for his country. One side says he carried a mediocre squad to the knockouts again. The other says the GOAT should be able to drag any team past France.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Messi was invisible in the 2018 knockouts. Before he won the World Cup in 2022, was he a fraud at international level — or just let down by the team around him. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: Argentina were eliminated in the round of 16 by France in 2018. Messi did not score...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 45,
+    "headline": "England used data and set pieces to reach the 2018 semifinal. Was it genius or a sign that football has become soulless and robotic?",
+    "description": "Gareth Southgate's England scored multiple set-piece goals and reached the last four in 2018 through meticulous preparation and analytics. Sky Sports called it a revolution. Critics said it was industrial football with no soul. Is data-driven tournament preparation the future of the game — or a betrayal of its spirit?",
+    "comments": [
+      "This is the hill I'll die on — England used data and set pieces to reach the 2018 semifinal. Was it genius or a sign that football has become soulless and robotic. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think Gareth Southgate's England scored multiple set-piece goals and reached the last four...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 46,
+    "headline": "Germany beat Brazil 7-1 in their own World Cup semifinal. Is it the most humiliating result in football history — full stop?",
+    "description": "Germany scored five goals in 18 first-half minutes in Belo Horizonte. The host nation, one of football's superpowers, were destroyed in front of their own people. One side says nothing in football history has come close to matching this in scale and shock. The other says humiliation is subjective — Brazil without Neymar and Thiago Silva was not a true representation of Brazil.",
+    "comments": [
+      "Look, everyone sleeping on this — Germany beat Brazil 7-1 in their own World Cup semifinal. Is it the most humiliating result in football history — full stop. The evidence is right there if you're willing to look.",
+      "Hard pass. Germany scored five goals in 18 first-half minutes in Belo Horizonte. The host...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 47,
+    "headline": "Brazil were awarded the 2014 World Cup while millions of citizens protested the money being spent on football instead of public services. Was hosting it morally justifiable?",
+    "description": "Protests erupted across Brazil during the 2013 Confederations Cup, with demonstrators carrying signs reading \"FIFA go home.\" The government spent billions on stadiums in cities that had no football infrastructure legacy. One side says sport drives economic growth and global visibility. The other says spending on stadiums while citizens lack hospitals and schools is a political failure.",
+    "comments": [
+      "Hard agree. Brazil were awarded the 2014 World Cup while millions of citizens protested the money being spent on football instead of public services. Was hosting it morally justifiable. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Protests erupted across Brazil during the 2013 Confederations Cup, with...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 48,
+    "headline": "Luis Suárez bit an opponent at the World Cup for the third time in his career. Was his four-month ban too harsh — or too lenient?",
+    "description": "Suárez bit Giorgio Chiellini during Uruguay's group game against Italy. It was his third biting incident across club and international football. FIFA banned him for four months and nine international games. One side says repeat offenders deserve heavier consequences — the ban was not enough. The other says banning a player from a once-in-a-generation tournament for biting — not a dangerous foul — was disproportionate.",
+    "comments": [
+      "Say it louder — Luis Suárez bit an opponent at the World Cup for the third time in his career. Was his four-month ban too harsh — or too lenient. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Suárez bit Giorgio Chiellini during Uruguay's group game against Italy. It was his...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 49,
+    "headline": "James Rodríguez won the Golden Boot in 2014 despite Colombia going out in the quarterfinals. Should the best individual at a World Cup always come from the winning team?",
+    "description": "Rodríguez scored six goals including a contender for the greatest strike in tournament history. Colombia didn't make the final. One side says individual brilliance should be celebrated regardless of team outcome — the Golden Boot is for the scorer, not the winners. The other says tournament football is about teams, and crowning the best player from a losing nation sends the wrong message.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: James Rodríguez won the Golden Boot in 2014 despite Colombia going out in the quarterfinals. Should the best individual at a World Cup always come from the winning team. The evidence is right there if you're willing to l",
+      "Everyone on the agree side is ignoring the obvious: Rodríguez scored six goals including a contender for the greatest strike in...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 50,
+    "headline": "Spain arrived as three-time defending major tournament winners and went home in the group stage. Was it the most complete collapse of a footballing dynasty ever seen?",
+    "description": "Spain had won Euro 2008, the 2010 World Cup, and Euro 2012 — football's first ever consecutive major tournament treble. In 2014, they lost 5-1 to the Netherlands and went out in the group stage without registering a single win. One side says it was an inevitable generational hangover. The other says losing to the Netherlands 5-1 as the greatest team in the world is a managerial catastrophe.",
+    "comments": [
+      "This is the hill I'll die on — Spain arrived as three-time defending major tournament winners and went home in the group stage. Was it the most complete collapse of a footballing dynasty ever seen. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think Spain had won Euro 2008, the 2010 World Cup, and Euro 2012 — football's first ever...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 51,
+    "headline": "Germany winning the 2014 World Cup in Brazil proved Europe can win in the Americas. Or was it a one-off that proves nothing?",
+    "description": "Of eight World Cups hosted in the Americas, only Germany in 2014 have been won by a European side. ESPN's 2026 coverage used this stat as a recurring debate point. One side says Germany's dominance proved the theory wrong — European technical football can overcome home advantage. The other says one exception in eight tournaments doesn't prove anything.",
+    "comments": [
+      "Look, everyone sleeping on this — Germany winning the 2014 World Cup in Brazil proved Europe can win in the Americas. Or was it a one-off that proves nothing. The evidence is right there if you're willing to look.",
+      "Hard pass. Of eight World Cups hosted in the Americas, only Germany in 2014 have been won by a...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 52,
+    "headline": "Frank Lampard's goal that wasn't given against Germany changed football history. Was it the most consequential refereeing error ever?",
+    "description": "Lampard's shot clearly crossed the line — by over a foot — but the goal was not awarded. England lost 4-1. The incident directly accelerated the introduction of goal-line technology. One side says it was simply the most famous of many bad refereeing decisions the sport has produced. The other says no single error had a bigger impact on how football is now officiated at every level.",
+    "comments": [
+      "Hard agree. Frank Lampard's goal that wasn't given against Germany changed football history. Was it the most consequential refereeing error ever. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Lampard's shot clearly crossed the line — by over a foot — but the goal was not...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 53,
+    "headline": "The Netherlands played cynically brutal football in the 2010 final and nearly won the World Cup. Should van Bommel, de Jong, and Robben have been sent off?",
+    "description": "The 2010 final saw 14 yellow cards — a World Cup record — and multiple dangerous challenges, including de Jong's kung-fu kick to Xabi Alonso's chest, which received only a yellow. One side says the referee, Howard Webb, completely lost control of the match. The other says the Netherlands were tactically eliminating Spain's best players and the referee was right to manage rather than escalate.",
+    "comments": [
+      "Say it louder — The Netherlands played cynically brutal football in the 2010 final and nearly won the World Cup. Should van Bommel, de Jong, and Robben have been sent off. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — The 2010 final saw 14 yellow cards — a World Cup record — and multiple dangerous...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 54,
+    "headline": "The vuvuzela was the soundtrack of the 2010 World Cup. Beloved cultural symbol or instrument of torture?",
+    "description": "The South African stadium horn divided the world. Broadcasters received thousands of complaints. Players said it disrupted on-pitch communication. One side says the vuvuzela was an authentic expression of South African football culture and attempting to ban it would have been cultural imperialism. The other says watching a World Cup where every conversation had to be shouted over a droning wall of noise was genuinely unbearable.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: The vuvuzela was the soundtrack of the 2010 World Cup. Beloved cultural symbol or instrument of torture. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: The South African stadium horn divided the world. Broadcasters received thousands of...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 55,
+    "headline": "South Africa 2010 was the first World Cup on African soil. Did FIFA wait too long — and is the continent still being underserved?",
+    "description": "Africa staged its first World Cup in 2010, 80 years after the first tournament. One side says South Africa 2010 was a milestone that transformed perceptions of the continent's ability to host global events. The other says with 54 FIFA member nations, Africa should have hosted the World Cup decades earlier and continues to be structurally disadvantaged in the bidding process.",
+    "comments": [
+      "This is the hill I'll die on — South Africa 2010 was the first World Cup on African soil. Did FIFA wait too long — and is the continent still being underserved. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think Africa staged its first World Cup in 2010, 80 years after the first tournament. One...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 56,
+    "headline": "Uruguay used their hand to stop a goal-bound header in the quarterfinal against Ghana. Should the rules be changed so a deliberate handball on the line results in an automatic goal?",
+    "description": "Luis Suárez deliberately handled Dominic Adiyiah's goal-bound header in the last minute of extra time. He was sent off. Ghana missed the resulting penalty and lost on spot-kicks. One side says the rules worked — Suárez paid his price, Ghana had their chance. The other says a handball on the line that denies a certain goal should result in an automatic goal, not just a penalty, because the cheating team still wins if the kick is missed.",
+    "comments": [
+      "Look, everyone sleeping on this — Uruguay used their hand to stop a goal-bound header in the quarterfinal against Ghana. Should the rules be changed so a deliberate handball on the line results in an automatic goal. The evidence is right there if you're willing to look.",
+      "Hard pass. Luis Suárez deliberately handled Dominic Adiyiah's goal-bound header in the last...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 57,
+    "headline": "Spain won the 2010 World Cup playing tiki-taka and barely scoring. Were they the most dominant yet most tedious champions in the tournament's history?",
+    "description": "Spain averaged 67% possession across the tournament but scored just eight goals in seven games, winning the final 1-0. One side says the level of technical control they demonstrated was historically unprecedented — the greatest footballing exhibition a World Cup has ever seen. The other says football decided by one goal with possession kept purely for its own sake is a form of aesthetic suffocation.",
+    "comments": [
+      "Hard agree. Spain won the 2010 World Cup playing tiki-taka and barely scoring. Were they the most dominant yet most tedious champions in the tournament's history. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Spain averaged 67% possession across the tournament but scored just eight goals in...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 58,
+    "headline": "Zidane headbutted Materazzi in the World Cup final and was sent off. Did he deserve to be remembered as a villain — or was Materazzi equally culpable?",
+    "description": "Zidane's headbutt was detected by the fourth official, not the referee. Zidane claimed Materazzi insulted his mother and sister. Materazzi later confirmed the insult but never apologised. One side says violent conduct is violent conduct — no verbal provocation justifies a headbutt in a World Cup final. The other says the victim in that incident wasn't Materazzi, and FIFA should have investigated what was said.",
+    "comments": [
+      "Say it louder — Zidane headbutted Materazzi in the World Cup final and was sent off. Did he deserve to be remembered as a villain — or was Materazzi equally culpable. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Zidane's headbutt was detected by the fourth official, not the referee. Zidane...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 59,
+    "headline": "Zidane was the best player at the 2006 World Cup and finished it with a red card. Does that destroy his legacy — or make it more human and more interesting?",
+    "description": "Zidane had announced his retirement before the tournament and was magnificent throughout — Panenka penalty, player of the tournament. Then came the headbutt, the red card, and a France defeat on penalties. One side says the red card is a tragic footnote on a perfect career. The other says it fundamentally changed the ending of his story — and not in a good way.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Zidane was the best player at the 2006 World Cup and finished it with a red card. Does that destroy his legacy — or make it more human and more interesting. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: Zidane had announced his retirement before the tournament and was magnificent...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 60,
+    "headline": "Portugal vs Netherlands in 2006 produced four red cards and 16 yellows. Should the referee have abandoned the match?",
+    "description": "The Battle of Nuremberg produced the dirtiest football ever seen at a World Cup. The match was barely a football match by the end. One side says the referee had a duty to abandon or forfeit the game to send a message. The other says players are responsible for their own conduct — you cannot blame the official for what 22 adults chose to do.",
+    "comments": [
+      "This is the hill I'll die on — Portugal vs Netherlands in 2006 produced four red cards and 16 yellows. Should the referee have abandoned the match. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think The Battle of Nuremberg produced the dirtiest football ever seen at a World Cup. The...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 61,
+    "headline": "Graham Poll booked Josip Šimunić three times before sending him off. Is it the single worst individual refereeing error in World Cup history?",
+    "description": "Poll issued a second yellow to Šimunić without a red card and then issued a third yellow before finally sending him off. The error was inexplicable. Poll retired from international football shortly after. One side says it is simply the most embarrassing individual officiating moment the sport has ever produced. The other argues that systemic refereeing errors — like Lampard's disallowed goal — had bigger consequences for the game.",
+    "comments": [
+      "Look, everyone sleeping on this — Graham Poll booked Josip Šimunić three times before sending him off. Is it the single worst individual refereeing error in World Cup history. The evidence is right there if you're willing to look.",
+      "Hard pass. Poll issued a second yellow to Šimunić without a red card and then issued a third...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 62,
+    "headline": "Italy won the 2006 World Cup in the middle of the Calciopoli match-fixing scandal. Should their title carry an asterisk?",
+    "description": "Italy lifted the 2006 World Cup while several of their top clubs — Juventus, AC Milan, Fiorentina, Lazio — were being investigated for match-fixing in Serie A. Several key Italian World Cup players were implicated. One side says the national team and the domestic scandal are entirely separate. The other says the integrity of Italian football was so compromised in 2006 that any championship associated with it is tainted.",
+    "comments": [
+      "Hard agree. Italy won the 2006 World Cup in the middle of the Calciopoli match-fixing scandal. Should their title carry an asterisk. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Italy lifted the 2006 World Cup while several of their top clubs — Juventus, AC...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 63,
+    "headline": "South Korea eliminated Spain and Italy in 2002 with the help of shocking refereeing decisions. Was their semifinal run legitimate?",
+    "description": "South Korea's run to the last four was accompanied by multiple decisions that defied explanation — disallowed goals, controversial red cards, and a Spanish goal ruled out for a marginal offside. One side says South Korea were a well-organised, genuinely excellent team who deserved to go far. The other says it was one of the most obviously rigged runs in World Cup history.",
+    "comments": [
+      "Say it louder — South Korea eliminated Spain and Italy in 2002 with the help of shocking refereeing decisions. Was their semifinal run legitimate. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — South Korea's run to the last four was accompanied by multiple decisions that defied...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 64,
+    "headline": "Ronaldo scored eight goals and won the World Cup in 2002 after his mystery seizure in 1998. Is it the greatest individual redemption story in football history?",
+    "description": "R9 Ronaldo went to the 1998 final in mysterious circumstances, barely played, and Brazil lost 3-0. In 2002 he scored eight goals and lifted the trophy. One side says the arc from 1998 to 2002 is the most complete redemption story the sport has ever produced. The other says a player of Ronaldo's ability winning one World Cup after missing another is not remarkable — it's what was expected all along.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Ronaldo scored eight goals and won the World Cup in 2002 after his mystery seizure in 1998. Is it the greatest individual redemption story in football history. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: R9 Ronaldo went to the 1998 final in mysterious circumstances, barely played, and...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 65,
+    "headline": "France arrived in 2002 as defending champions, didn't score a single goal, and went out in the group stage. Is it the greatest defending champion collapse in history?",
+    "description": "The 1998 champions and 2000 European champions France were eliminated in 2002 without scoring a single goal, with Zidane playing only one game due to injury. One side says it's the single most shocking fall from grace in tournament history. The other argues Germany in 2018 — as reigning champions — is even worse because it came with no major injury excuse.",
+    "comments": [
+      "This is the hill I'll die on — France arrived in 2002 as defending champions, didn't score a single goal, and went out in the group stage. Is it the greatest defending champion collapse in history. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think The 1998 champions and 2000 European champions France were eliminated in 2002...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 66,
+    "headline": "Turkey finished third at the 2002 World Cup and it remains their greatest ever achievement. Should a nation of 85 million people have done more with their golden generation?",
+    "description": "Şükür, Hakan Şükür's goal after 11 seconds — the fastest in World Cup history — and Turkey's third-place finish remain their high-water mark. One side says it was a miracle overachievement for a country without a major football infrastructure. The other says Turkey's population, talent pool, and resources should have delivered more major trophies than one World Cup third place across 100 years of football.",
+    "comments": [
+      "Look, everyone sleeping on this — Turkey finished third at the 2002 World Cup and it remains their greatest ever achievement. Should a nation of 85 million people have done more with their golden generation. The evidence is right there if you're willing to look.",
+      "Hard pass. Şükür, Hakan Şükür's goal after 11 seconds — the fastest in World Cup history — and...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 67,
+    "headline": "Something happened to Ronaldo before the 1998 World Cup final. Brazil played him anyway and lost 3-0. Was that negligence or was the truth never told?",
+    "description": "Ronaldo suffered a convulsive episode hours before the final. He was initially left off the team sheet, then reinstated without explanation. Brazil lost 3-0 to France. He barely touched the ball. One side says putting a player through a medical episode onto a World Cup final pitch was negligent. The other says Ronaldo was cleared to play and the decision was his to make. What really happened that night in Paris?",
+    "comments": [
+      "Hard agree. Something happened to Ronaldo before the 1998 World Cup final. Brazil played him anyway and lost 3-0. Was that negligence or was the truth never told. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Ronaldo suffered a convulsive episode hours before the final. He was initially left...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 68,
+    "headline": "David Beckham got a red card against Argentina in 1998 for flicking his boot at Simeone. Did that one moment of stupidity cost England a World Cup?",
+    "description": "Beckham was sent off for a petulant kick at Diego Simeone. England played the rest of the game with ten men and lost on penalties. One side says England had enough players to win with ten — the loss was collective. The other says eliminating your best creative player against Argentina in a World Cup knockout is an act of self-destruction that cannot be excused, regardless of what Simeone did first.",
+    "comments": [
+      "Say it louder — David Beckham got a red card against Argentina in 1998 for flicking his boot at Simeone. Did that one moment of stupidity cost England a World Cup. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Beckham was sent off for a petulant kick at Diego Simeone. England played the rest...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 69,
+    "headline": "Diego Simeone theatrically went to ground to get Beckham sent off in 1998. Is that gamesmanship or cheating?",
+    "description": "Simeone made the most of minimal contact from Beckham to ensure the referee saw it and reacted. He later admitted the strategy was deliberate. One side says working the referee is an accepted part of elite football — Simeone was brilliant at it. The other says manufacturing a player's red card through deception is cheating, and Simeone should have received a yellow card for simulation.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Diego Simeone theatrically went to ground to get Beckham sent off in 1998. Is that gamesmanship or cheating. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: Simeone made the most of minimal contact from Beckham to ensure the referee saw it...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 70,
+    "headline": "Zidane's two-header performance in the 1998 World Cup final. Is it the greatest display by a player in a final — ever?",
+    "description": "Zidane scored twice from corners in the first half against Brazil, directing France to a 3-0 win and their first World Cup. BeIN Sports and Sky Sports have both called it the defining World Cup final performance of the modern era. One side says no player has controlled a final from midfield the way Zidane did that night. The other says Messi's performance across the 2022 final — two goals, a penalty, extra time heroics — surpasses it.",
+    "comments": [
+      "This is the hill I'll die on — Zidane's two-header performance in the 1998 World Cup final. Is it the greatest display by a player in a final — ever. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think Zidane scored twice from corners in the first half against Brazil, directing France...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 71,
+    "headline": "Maradona tested positive for drugs at the 1994 World Cup. Was he a victim of an agenda to remove him — or did he cheat himself out of a final farewell?",
+    "description": "Maradona tested positive for ephedrine — a substance found in several common cold remedies — and was expelled from the tournament at the peak of what looked like a genuine comeback. One side says FIFA was determined to end the Maradona era and the timing was not a coincidence. The other says if you take banned substances, you face the consequences — no matter who you are.",
+    "comments": [
+      "Look, everyone sleeping on this — Maradona tested positive for drugs at the 1994 World Cup. Was he a victim of an agenda to remove him — or did he cheat himself out of a final farewell. The evidence is right there if you're willing to look.",
+      "Hard pass. Maradona tested positive for ephedrine — a substance found in several common cold...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 72,
+    "headline": "Roberto Baggio was the best player at the 1994 World Cup and missed the penalty that decided it. Is it the most heartbreaking moment in football history?",
+    "description": "Baggio carried Italy through the tournament, scored in five consecutive games, and then hit the final penalty over the bar to hand Brazil the World Cup. He has described it as the worst moment of his life. One side says the image of Baggio with his head bowed is the defining image of sporting heartbreak. The other says penalty shootouts are lottery — the individual who misses is not responsible for losing a World Cup alone.",
+    "comments": [
+      "Hard agree. Roberto Baggio was the best player at the 1994 World Cup and missed the penalty that decided it. Is it the most heartbreaking moment in football history. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Baggio carried Italy through the tournament, scored in five consecutive games, and...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 73,
+    "headline": "Andrés Escobar was shot dead after scoring an own goal against the USA. Did football fail him — or was his death entirely about Colombian society and organised crime?",
+    "description": "Escobar's own goal helped eliminate Colombia in 1994. He was murdered ten days later. One side says football needs to take responsibility for the environment it creates — the pressure on Colombian players from drug cartel-linked football culture was known, and nothing was done. The other says sport cannot be held responsible for the criminal actions of individuals in a country.",
+    "comments": [
+      "Say it louder — Andrés Escobar was shot dead after scoring an own goal against the USA. Did football fail him — or was his death entirely about Colombian society and organised crime. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Escobar's own goal helped eliminate Colombia in 1994. He was murdered ten days...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 74,
+    "headline": "The 1994 World Cup was held in the USA and barely anyone there cared about football. Was it the right choice then — and did it matter in the long run?",
+    "description": "The 1994 World Cup drew record average attendances but played out against a backdrop of American apathy toward the sport. Critics said giving football's biggest stage to a country that didn't care about football was an insult to the game. Supporters say it planted the seeds for MLS, the USMNT's growth, and ultimately the 2026 hosting rights. Did 1994 change American football culture forever — or would that have happened anyway?",
+    "comments": [
+      "The agree side is winning this argument and it's not close: The 1994 World Cup was held in the USA and barely anyone there cared about football. Was it the right choice then — and did it matter in the long run. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: The 1994 World Cup drew record average attendances but played out against a backdrop...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 75,
+    "headline": "Italia 90 averaged 2.21 goals per game — the lowest in World Cup history. Was it the worst tournament ever played — or a masterclass in tactical football?",
+    "description": "The 1990 World Cup was dominated by defensive football, stalemates, and penalty shootouts. Neutral observers were left bored. One side says it was unwatchable — a tournament that forced FIFA to change the backpass rule and the offside law. The other says tactical organisation is a legitimate art form, and calling it \"boring\" dismisses the craft involved.",
+    "comments": [
+      "This is the hill I'll die on — Italia 90 averaged 2.21 goals per game — the lowest in World Cup history. Was it the worst tournament ever played — or a masterclass in tactical football. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think The 1990 World Cup was dominated by defensive football, stalemates, and penalty...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 76,
+    "headline": "Uruguay's deliberate foul to deny a goal, Ghana's missed penalty, Suárez cheating. Which side of history do you stand on — the villain or the tactician?",
+    "description": "The Suárez handball against Ghana in 2010 is the modern version of a debate that has defined football: is deliberately breaking the rules to gain an advantage cheating, or is it tactical intelligence within the framework of the sport? Italia 90 produced similar debates. Where is the line between gamesmanship and dishonesty in football?",
+    "comments": [
+      "Look, everyone sleeping on this — Uruguay's deliberate foul to deny a goal, Ghana's missed penalty, Suárez cheating. Which side of history do you stand on — the villain or the tactician. The evidence is right there if you're willing to look.",
+      "Hard pass. The Suárez handball against Ghana in 2010 is the modern version of a debate that has...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 77,
+    "headline": "Cameroon beat the defending champions Argentina in the 1990 opener. Is it still the greatest upset in World Cup history?",
+    "description": "Cameroon defeated Maradona's Argentina in the opening game of the 1990 World Cup — with ten men — and went on to reach the quarterfinals. One side says it remains the most shocking result in the tournament's history. The other says modern upsets — Senegal over France in 2002, Germany over Brazil in 2014 — have long since surpassed it.",
+    "comments": [
+      "Hard agree. Cameroon beat the defending champions Argentina in the 1990 opener. Is it still the greatest upset in World Cup history. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Cameroon defeated Maradona's Argentina in the opening game of the 1990 World Cup —...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 78,
+    "headline": "Maradona punched the ball into England's net, celebrated it, and called it the Hand of God. Is it the greatest act of dishonesty in sport — or football's most iconic moment?",
+    "description": "Maradona used his fist to score in the 1986 quarterfinal against England, deceived the referee, and then invented a spiritual defence for it. One side says it was a calculated cheat that robbed England of a legitimate World Cup shot and should be remembered as such. The other says the legend that was built around the moment — the defiance, the audacity, the poetry of calling it God's goal — is precisely what makes football the sport it is.",
+    "comments": [
+      "Say it louder — Maradona punched the ball into England's net, celebrated it, and called it the Hand of God. Is it the greatest act of dishonesty in sport — or football's most iconic moment. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Maradona used his fist to score in the 1986 quarterfinal against England, deceived...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 79,
+    "headline": "Maradona's second goal against England in 1986 was voted Goal of the Century. Does any goal in football history come close?",
+    "description": "Four minutes after the handball, Maradona dribbled from the halfway line, past five England players and the goalkeeper, to score one of the most technically perfect individual goals ever recorded. FIFA's public vote gave it the century. One side says the debate is closed. The other says it benefits from context — being scored by the same player, in the same game, minutes after the most infamous moment in World Cup history.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Maradona's second goal against England in 1986 was voted Goal of the Century. Does any goal in football history come close. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: Four minutes after the handball, Maradona dribbled from the halfway line, past five...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 80,
+    "headline": "Maradona essentially won the 1986 World Cup alone. Is his tournament the greatest individual performance in football history — or is it unfair to compare eras?",
+    "description": "Maradona scored five goals and created five more, personally dismantling Belgium and England along the way. ESPN and BeIN Sports both rank his 1986 campaign as the definitive one-man World Cup. One side says no player before or since has dragged a team to a World Cup through individual brilliance to the same degree. The other says comparing across eras is meaningless without controlling for the quality of opponents and tactical evolution.",
+    "comments": [
+      "This is the hill I'll die on — Maradona essentially won the 1986 World Cup alone. Is his tournament the greatest individual performance in football history — or is it unfair to compare eras. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think Maradona scored five goals and created five more, personally dismantling Belgium and...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 81,
+    "headline": "Should FIFA have used available 1986 video evidence to disallow the Hand of God goal — even after the match?",
+    "description": "Footage of Maradona's handball was available and unambiguous within minutes of the goal being scored. FIFA took no action. One side says sport's integrity demands retroactive correction when clear evidence exists. The other says you cannot change results after the final whistle — where does that precedent end?",
+    "comments": [
+      "Look, everyone sleeping on this — Should FIFA have used available 1986 video evidence to disallow the Hand of God goal — even after the match. The evidence is right there if you're willing to look.",
+      "Hard pass. Footage of Maradona's handball was available and unambiguous within minutes of the...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 82,
+    "headline": "West Germany and Austria played out the exact result they needed to eliminate Algeria in 1982. Was it football's most blatant conspiracy?",
+    "description": "The Disgrace of Gijón saw West Germany and Austria play a passive 1-0 match in their final group game — a result that eliminated Algeria and sent both European sides through. Players from both sides barely pressed or attacked after the opening goal. One side says it was obvious collusion and should have resulted in both teams being disqualified. The other says no one could prove intent and both teams were simply managing a result within the rules.",
+    "comments": [
+      "Hard agree. West Germany and Austria played out the exact result they needed to eliminate Algeria in 1982. Was it football's most blatant conspiracy. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — The Disgrace of Gijón saw West Germany and Austria play a passive 1-0 match in their...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 83,
+    "headline": "Brazil's 1982 squad played the most beautiful football ever seen at a World Cup and were eliminated in the group stage. Are they the greatest team never to win it?",
+    "description": "The 1982 Brazil side — Zico, Sócrates, Falcão, Éder — played football widely described as the best the World Cup has ever produced and went out to Italy. One side says they are the most heartbreaking case of talent without reward in the tournament's history. The other says results determine greatness — being beautiful and losing is still losing.",
+    "comments": [
+      "Say it louder — Brazil's 1982 squad played the most beautiful football ever seen at a World Cup and were eliminated in the group stage. Are they the greatest team never to win it. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — The 1982 Brazil side — Zico, Sócrates, Falcão, Éder — played football widely...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 84,
+    "headline": "Argentina won the 1978 World Cup under a military dictatorship that was imprisoning dissidents near the stadiums. Should the title be recognised?",
+    "description": "The 1978 World Cup was played with political prisoners held in detention facilities audible from the training grounds. The junta used the tournament as propaganda. One side says the players were not the regime and stripping their title punishes athletes for their government. The other says awarding and recognising a World Cup hosted under a dictatorship that used sport to legitimise itself is morally indefensible.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Argentina won the 1978 World Cup under a military dictatorship that was imprisoning dissidents near the stadiums. Should the title be recognised. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: The 1978 World Cup was played with political prisoners held in detention facilities...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 85,
+    "headline": "Argentina beat Peru 6-0 in 1978 — exactly the margin they needed to reach the final. Was it one of the most suspicious results in football history?",
+    "description": "Argentina needed to beat Peru by four goals to leapfrog Brazil. They won 6-0. Peru's goalkeeper was Argentine-born. No definitive evidence of a fix was ever produced, but the result has never stopped generating suspicion. One side says the scoreline was suspicious beyond reasonable doubt. The other says Argentina were a strong team, Peru were weak, and conspiracy theories fill the void where evidence is absent.",
+    "comments": [
+      "This is the hill I'll die on — Argentina beat Peru 6-0 in 1978 — exactly the margin they needed to reach the final. Was it one of the most suspicious results in football history. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think Argentina needed to beat Peru by four goals to leapfrog Brazil. They won 6-0. Peru's...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 86,
+    "headline": "Geoff Hurst's goal in the 1966 World Cup final didn't cross the line. Does that mean England's only World Cup is tainted forever?",
+    "description": "The ball bounced down from the underside of the crossbar and was awarded as a goal by the Soviet linesman. Germany have disputed it for nearly 60 years. Modern analysis has never conclusively confirmed the ball crossed the line. One side says the referee's decision stands and England won it fair and square. The other says the most significant goal in English football history should not have been given — and every England fan knows it.",
+    "comments": [
+      "Look, everyone sleeping on this — Geoff Hurst's goal in the 1966 World Cup final didn't cross the line. Does that mean England's only World Cup is tainted forever. The evidence is right there if you're willing to look.",
+      "Hard pass. The ball bounced down from the underside of the crossbar and was awarded as a goal...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 87,
+    "headline": "England won the World Cup as hosts in 1966. Would they have won it on neutral ground?",
+    "description": "England were drawn in groups played at Wembley, never played away from home, and benefited from a deeply questionable goal in the final. One side says hosts always have an advantage and England used it effectively — that's part of the game. The other says England's only World Cup win was so uniquely dependent on home advantage, referee sympathy, and a disputed goal that it tells us nothing about how good that England team actually were.",
+    "comments": [
+      "Hard agree. England won the World Cup as hosts in 1966. Would they have won it on neutral ground. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — England were drawn in groups played at Wembley, never played away from home, and...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 88,
+    "headline": "Messi has the World Cup. Maradona has 1986. Who is the greatest Argentine footballer of all time — and can the debate ever be closed?",
+    "description": "Messi: six Ballon d'Ors, a World Cup, the greatest final in history, a 2026 scoring record. Maradona: won a World Cup essentially alone with a squad of average players. One side says collective stats and trophies make Messi the obvious answer. The other says Maradona's 1986 tournament was a singular act of individual will that Messi — always with great teams around him — has never had to produce.",
+    "comments": [
+      "Say it louder — Messi has the World Cup. Maradona has 1986. Who is the greatest Argentine footballer of all time — and can the debate ever be closed. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Messi: six Ballon d'Ors, a World Cup, the greatest final in history, a 2026 scoring...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 89,
+    "headline": "Messi vs Ronaldo: is it the greatest individual rivalry in the history of sport — or were they just very good at the same time?",
+    "description": "Both players scored at six World Cups. Both broke records at the 2026 tournament. ESPN and Sky Sports have covered this debate for 20 years. One side says the simultaneous emergence of two players at this level, in the same era and same league, is statistically impossible to recreate and defines a golden age. The other says rivalry requires genuine competition — and Messi has always been ahead.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Messi vs Ronaldo: is it the greatest individual rivalry in the history of sport — or were they just very good at the same time. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: Both players scored at six World Cups. Both broke records at the 2026 tournament....",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 90,
+    "headline": "VAR has been in football for eight years. Has it made the game more fair — or just created new injustices to replace the old ones?",
+    "description": "VAR was introduced to eliminate clear and obvious errors. Instead it has produced toenail offsides, controversial handball interpretations, and minutes-long delays that kill momentum. One side says the data shows fewer clear injustices since VAR — it's working. The other says the sport lost something irreplaceable when human error was mediated by technology and the emotional spontaneity of football was replaced by waiting for a screen.",
+    "comments": [
+      "This is the hill I'll die on — VAR has been in football for eight years. Has it made the game more fair — or just created new injustices to replace the old ones. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think VAR was introduced to eliminate clear and obvious errors. Instead it has produced...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 91,
+    "headline": "Should the World Cup be held every two years? FIFA want it. UEFA, players' unions, and most fans don't. Who's right?",
+    "description": "FIFA has repeatedly pushed for a biennial World Cup. UEFA have threatened a European boycott. Player welfare groups cite fixture congestion and burnout. One side says holding the World Cup every two years grows the game, gives more nations a shot, and generates more revenue for development. The other says the World Cup only matters because it happens once every four years — make it annual and it's just another tournament.",
+    "comments": [
+      "Look, everyone sleeping on this — Should the World Cup be held every two years? FIFA want it. UEFA, players' unions, and most fans don't. Who's right. The evidence is right there if you're willing to look.",
+      "Hard pass. FIFA has repeatedly pushed for a biennial World Cup. UEFA have threatened a European...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 92,
+    "headline": "The Women's World Cup prize fund is a fraction of the men's. Is FIFA's pay disparity football's most embarrassing ongoing inequality?",
+    "description": "Women's World Cup prize money has increased but remains far below the men's equivalent. One side says pay should reflect revenue — until women's football generates comparable commercial returns, comparable prize money is not sustainable. The other says FIFA is the largest football organisation on earth and has a responsibility to invest in the women's game, not just distribute revenue from it.",
+    "comments": [
+      "Hard agree. The Women's World Cup prize fund is a fraction of the men's. Is FIFA's pay disparity football's most embarrassing ongoing inequality. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Women's World Cup prize money has increased but remains far below the men's...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 93,
+    "headline": "Should countries with poor human rights records ever be allowed to host the World Cup?",
+    "description": "Qatar 2022, Russia 2018, and Saudi Arabia 2034 collectively span three of the most controversial hosting decisions in sporting history. One side says engagement and the spotlight of global scrutiny can drive genuine reform — isolating nations achieves nothing. The other says FIFA is actively rewarding authoritarian regimes with the prestige of the world's biggest sporting event and legitimising their governance in the process.",
+    "comments": [
+      "Say it louder — Should countries with poor human rights records ever be allowed to host the World Cup. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Qatar 2022, Russia 2018, and Saudi Arabia 2034 collectively span three of the most...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 94,
+    "headline": "The European Super League would have destroyed the World Cup. Or would it?",
+    "description": "In 2021 twelve elite clubs attempted to form a breakaway closed competition. It collapsed within 48 hours. One side says had the ESL succeeded, national team football — including the World Cup — would have been fatally weakened as club football consumed the best players, the best TV slots, and the biggest audiences. The other says national team football was always going to survive regardless — the World Cup is too emotionally embedded to be killed by club competition.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: The European Super League would have destroyed the World Cup. Or would it. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: In 2021 twelve elite clubs attempted to form a breakaway closed competition. It...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 95,
+    "headline": "Is the World Cup the greatest sporting event on earth — or has the Champions League quietly overtaken it?",
+    "description": "The 2022 World Cup final drew 1.5 billion viewers. Champions League finals now regularly attract audiences in the hundreds of millions and generate as much media coverage as the World Cup. One side says nothing in sport matches the scale, the national pride, or the emotional weight of the World Cup. The other says elite club football is now watched by more people more consistently than international football — and fans care more about their clubs than their countries.",
+    "comments": [
+      "This is the hill I'll die on — Is the World Cup the greatest sporting event on earth — or has the Champions League quietly overtaken it. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think The 2022 World Cup final drew 1.5 billion viewers. Champions League finals now...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 96,
+    "headline": "Is refereeing at the World Cup getting better or worse — and should referees be full-time professionals?",
+    "description": "Every World Cup produces major refereeing controversies — from Graham Poll's triple booking to Lampard's ghost goal to the 2022 armband ban to 2026's toenail offsides. One side says errors are inevitable in a fast, physical game — the real scandal is that referees are still part-time in the professional era. The other says officiating has been improved by technology and errors are being reduced year on year.",
+    "comments": [
+      "Look, everyone sleeping on this — Is refereeing at the World Cup getting better or worse — and should referees be full-time professionals. The evidence is right there if you're willing to look.",
+      "Hard pass. Every World Cup produces major refereeing controversies — from Graham Poll's triple...",
+      "Wild angle nobody's saying — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 97,
+    "headline": "The Golden Ball has been awarded to players on losing teams. Should the best player of a World Cup always come from the winning nation?",
+    "description": "Messi won the 2014 Golden Ball despite Argentina losing the final. Matthias Sammer won it in 1996 (European Championships). One side says the award should go to the individual who contributed most to the tournament, regardless of team outcome. The other says football is a team sport and rewarding the best player on a losing team sends a contradictory message about what tournaments are actually about.",
+    "comments": [
+      "Hard agree. The Golden Ball has been awarded to players on losing teams. Should the best player of a World Cup always come from the winning nation. The evidence is right there if you're willing to look.",
+      "The disagree camp has this one — Messi won the 2014 Golden Ball despite Argentina losing the final. Matthias Sammer...",
+      "Here's the real debate hiding underneath — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 98,
+    "headline": "Should penalty shootouts be abolished as a way to decide World Cup knockout games?",
+    "description": "Shootouts have decided some of the most iconic World Cup moments — and produced some of its most heartbreaking ones. One side says they're an artificial lottery that has nothing to do with football ability and should be replaced with replays, golden goals, or extended play. The other says the tension, the drama, and the psychological battle of a penalty shootout is one of sport's most compelling spectacles and should never be removed.",
+    "comments": [
+      "Say it louder — Should penalty shootouts be abolished as a way to decide World Cup knockout games. The evidence is right there if you're willing to look.",
+      "Respectfully, that's revisionist — Shootouts have decided some of the most iconic World Cup moments — and produced some...",
+      "Hot take that'll get me ratio'd — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 99,
+    "headline": "Has the World Cup become too big — too many games, too much politics, too much money, not enough football?",
+    "description": "From 48 teams in 2026 to $33,000 final tickets, ICE agents at stadiums, CO₂ crises, and halftime shows — the modern World Cup is barely recognisable from the tournament of 30 years ago. One side says growth is inevitable and the game reaching more people is always good. The other says FIFA has turned a sporting event into a geopolitical and commercial monster that no longer has the actual sport at its centre.",
+    "comments": [
+      "The agree side is winning this argument and it's not close: Has the World Cup become too big — too many games, too much politics, too much money, not enough football. The evidence is right there if you're willing to look.",
+      "Everyone on the agree side is ignoring the obvious: From 48 teams in 2026 to $33,000 final tickets, ICE agents at stadiums, CO₂ crises,...",
+      "Forget agree vs disagree — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  },
+  {
+    "id": 100,
+    "headline": "If you could go back and watch any World Cup match in history live, which one — and why does your answer reveal what you really think football is for?",
+    "description": "From Maradona vs England in 1986 to Zidane's final night in Berlin to Messi and Mbappé in 2022 — every fan has a moment that defines why they love the game. Is the World Cup ultimately about individual genius, team achievement, cultural identity, or pure drama? Your answer reveals everything.",
+    "comments": [
+      "This is the hill I'll die on — If you could go back and watch any World Cup match in history live, which one — and why does your answer reveal what you really think football is for. The evidence is right there if you're willing to look.",
+      "Nah, you're coping if you think From Maradona vs England in 1986 to Zidane's final night in Berlin to Messi and...",
+      "Unpopular take: both camps are wrong — the question isn't who wins the argument — it's whether this debate even captures what actually happened."
+    ]
+  }
+]

--- a/services/api/internal/ai/reference_debates_test.go
+++ b/services/api/internal/ai/reference_debates_test.go
@@ -1,0 +1,73 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadReferenceDebates(t *testing.T) {
+	debates, err := LoadReferenceDebates()
+	if err != nil {
+		t.Fatalf("LoadReferenceDebates() error = %v", err)
+	}
+	if len(debates) != 100 {
+		t.Fatalf("LoadReferenceDebates() count = %d, want 100", len(debates))
+	}
+	for _, d := range debates {
+		if strings.TrimSpace(d.Headline) == "" {
+			t.Fatalf("debate #%d missing headline", d.ID)
+		}
+		if strings.TrimSpace(d.Description) == "" {
+			t.Fatalf("debate #%d missing description", d.ID)
+		}
+		if len(d.Comments) != 3 {
+			t.Fatalf("debate #%d has %d comments, want 3", d.ID, len(d.Comments))
+		}
+		for i, c := range d.Comments {
+			if strings.TrimSpace(c) == "" {
+				t.Fatalf("debate #%d comment %d is empty", d.ID, i+1)
+			}
+		}
+	}
+}
+
+func TestReferenceDebatesPromptSection(t *testing.T) {
+	section := ReferenceDebatesPromptSection()
+	if section == "" {
+		t.Fatal("ReferenceDebatesPromptSection() returned empty string")
+	}
+	if !strings.Contains(section, "REFERENCE CORPUS") {
+		t.Error("prompt section should mention REFERENCE CORPUS")
+	}
+	if !strings.Contains(section, "Fucci's Take") {
+		t.Error("prompt section should mention Fucci's Take")
+	}
+	if !strings.Contains(section, "Messi scored all five") {
+		t.Error("prompt section should include example headline from corpus")
+	}
+}
+
+func TestBuildSystemPrompt_IncludesReferenceCorpus(t *testing.T) {
+	pg := &PromptGenerator{}
+	pre := pg.buildSystemPrompt("pre_match")
+	post := pg.buildSystemPrompt("post_match")
+	for _, prompt := range []string{pre, post} {
+		if !strings.Contains(prompt, "REFERENCE CORPUS") {
+			t.Error("system prompt should include reference corpus section")
+		}
+		if !strings.Contains(prompt, "Fucci's Take") {
+			t.Error("system prompt should mention Fucci's Take comments")
+		}
+	}
+}
+
+func TestBuildSystemPromptForSet_IncludesReferenceCorpus(t *testing.T) {
+	pg := &PromptGenerator{}
+	prompt := pg.buildSystemPromptForSet("pre_match", 3)
+	if !strings.Contains(prompt, "REFERENCE CORPUS") {
+		t.Error("set system prompt should include reference corpus section")
+	}
+	if !strings.Contains(prompt, "Fucci's Take") {
+		t.Error("set system prompt should mention Fucci's Take comments")
+	}
+}

--- a/services/api/internal/api/comments.go
+++ b/services/api/internal/api/comments.go
@@ -89,7 +89,7 @@ func checkCommentRateLimit(ctx context.Context, c *Config, userID int32) bool {
 	return defaultCommentRateLimiter.allow(userID)
 }
 
-// DebateComment is the public API shape for a comment (006 spec). Seeded flag is not exposed.
+// DebateComment is the public API shape for a comment (006 spec).
 type DebateComment struct {
 	ID              int32           `json:"id"`
 	DebateID        int32           `json:"debate_id"`
@@ -100,6 +100,7 @@ type DebateComment struct {
 	Content         string          `json:"content"`
 	CreatedAt       time.Time       `json:"created_at"`
 	NetScore        int32           `json:"net_score"`
+	IsFucciTake     bool            `json:"is_fucci_take"`
 	CurrentUserVote *string         `json:"current_user_vote,omitempty"` // "upvote" | "downvote" | null when unauthenticated
 	Reactions       []ReactionCount `json:"reactions"`
 	Subcomments     []DebateComment `json:"subcomments,omitempty"`
@@ -556,6 +557,7 @@ func (c *Config) buildDebateCommentFromRowWithPreloaded(
 		Content:         row.Content,
 		CreatedAt:       createdAt,
 		NetScore:        netScore,
+		IsFucciTake:     row.Seeded,
 		Reactions:       reactions,
 		CurrentUserVote: currentUserVote,
 	}

--- a/services/api/internal/api/debate_data_aggregator.go
+++ b/services/api/internal/api/debate_data_aggregator.go
@@ -40,6 +40,7 @@ type MatchDataRequest struct {
 	Venue           string `json:"venue"`
 	League          string `json:"league"`
 	Season          string `json:"season"`
+	Round           string `json:"round"`
 	LeagueID        int    `json:"league_id"`
 	SeasonYear      int    `json:"season_year"`
 	HomeTeamID      int    `json:"home_team_id"`
@@ -63,6 +64,7 @@ func (dda *DebateDataAggregator) AggregateMatchData(ctx context.Context, matchRe
 		Venue:    matchReq.Venue,
 		League:   matchReq.League,
 		Season:   matchReq.Season,
+		Round:    matchReq.Round,
 	}
 
 	// Create enhanced stats with the data we already have

--- a/services/api/internal/api/debates.go
+++ b/services/api/internal/api/debates.go
@@ -1994,6 +1994,7 @@ func (c *Config) getMatchInfo(ctx context.Context, matchID string) (*MatchInfo, 
 				ID     int    `json:"id"`
 				Name   string `json:"name"`
 				Season int    `json:"season"`
+				Round  string `json:"round"`
 			} `json:"league"`
 		} `json:"response"`
 	}
@@ -2057,6 +2058,7 @@ func (c *Config) getMatchInfo(ctx context.Context, matchID string) (*MatchInfo, 
 		Venue:           match.Fixture.Venue.Name,
 		League:          match.League.Name,
 		Season:          fmt.Sprintf("%d", match.League.Season),
+		Round:           match.League.Round,
 		LeagueID:        match.League.ID,
 		SeasonYear:      match.League.Season,
 		HomeTeamID:      match.Teams.Home.ID,
@@ -2429,6 +2431,7 @@ type MatchInfo struct {
 	Venue           string
 	League          string
 	Season          string
+	Round           string
 	LeagueID        int
 	SeasonYear      int
 	HomeTeamID      int
@@ -2460,6 +2463,7 @@ func (c *Config) buildMatchDataRequest(matchID string, matchInfo *MatchInfo) Mat
 		Venue:           matchInfo.Venue,
 		League:          matchInfo.League,
 		Season:          matchInfo.Season,
+		Round:           matchInfo.Round,
 		LeagueID:        matchInfo.LeagueID,
 		SeasonYear:      matchInfo.SeasonYear,
 		HomeTeamID:      matchInfo.HomeTeamID,

--- a/services/api/internal/database/debates.sql.go
+++ b/services/api/internal/database/debates.sql.go
@@ -776,7 +776,7 @@ WITH feed_candidates AS (
     FROM debates d
     LEFT JOIN debate_analytics da ON d.id = da.debate_id
     WHERE d.deleted_at IS NULL
-      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '6 days'
+      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '48 hours'
       AND EXISTS (SELECT 1 FROM debate_cards dc0 WHERE dc0.debate_id = d.id AND dc0.stance IN ('agree', 'disagree'))
       AND NOT EXISTS (
         SELECT 1
@@ -900,7 +900,7 @@ WITH feed_candidates AS (
     ) uv ON uv.debate_id = d.id
     LEFT JOIN debate_analytics da ON d.id = da.debate_id
     WHERE d.deleted_at IS NULL
-      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '6 days'
+      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '48 hours'
       AND EXISTS (SELECT 1 FROM debate_cards dc0 WHERE dc0.debate_id = d.id AND dc0.stance IN ('agree', 'disagree'))
     ORDER BY uv.last_voted_at DESC NULLS LAST
     LIMIT $2
@@ -1006,7 +1006,7 @@ WITH feed_candidates AS (
     FROM debates d
     LEFT JOIN debate_analytics da ON d.id = da.debate_id
     WHERE d.deleted_at IS NULL
-      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '6 days'
+      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '48 hours'
       AND EXISTS (SELECT 1 FROM debate_cards dc WHERE dc.debate_id = d.id)
     ORDER BY da.engagement_score DESC NULLS LAST, d.created_at DESC
     LIMIT $1

--- a/services/api/sql/queries/debates.sql
+++ b/services/api/sql/queries/debates.sql
@@ -172,7 +172,7 @@ WITH feed_candidates AS (
     FROM debates d
     LEFT JOIN debate_analytics da ON d.id = da.debate_id
     WHERE d.deleted_at IS NULL
-      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '6 days'
+      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '48 hours'
       AND EXISTS (SELECT 1 FROM debate_cards dc WHERE dc.debate_id = d.id)
     ORDER BY da.engagement_score DESC NULLS LAST, d.created_at DESC
     LIMIT $1
@@ -213,7 +213,7 @@ WITH feed_candidates AS (
     FROM debates d
     LEFT JOIN debate_analytics da ON d.id = da.debate_id
     WHERE d.deleted_at IS NULL
-      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '6 days'
+      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '48 hours'
       AND EXISTS (SELECT 1 FROM debate_cards dc0 WHERE dc0.debate_id = d.id AND dc0.stance IN ('agree', 'disagree'))
       AND NOT EXISTS (
         SELECT 1
@@ -273,7 +273,7 @@ WITH feed_candidates AS (
     ) uv ON uv.debate_id = d.id
     LEFT JOIN debate_analytics da ON d.id = da.debate_id
     WHERE d.deleted_at IS NULL
-      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '6 days'
+      AND d.created_at >= CURRENT_TIMESTAMP - INTERVAL '48 hours'
       AND EXISTS (SELECT 1 FROM debate_cards dc0 WHERE dc0.debate_id = d.id AND dc0.stance IN ('agree', 'disagree'))
     ORDER BY uv.last_voted_at DESC NULLS LAST
     LIMIT $2

--- a/yarn.lock
+++ b/yarn.lock
@@ -4646,11 +4646,6 @@ event-target-shim@^5.0.0, event-target-shim@^5.0.1:
   resolved "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-events@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
-  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
-
 exec-async@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz"
@@ -4724,7 +4719,7 @@ expo-camera@~17.0.10:
   dependencies:
     invariant "^2.2.4"
 
-expo-constants@~18.0.11, expo-constants@~18.0.12, expo-constants@~18.0.13:
+expo-constants@18.0.13, expo-constants@~18.0.11, expo-constants@~18.0.12, expo-constants@~18.0.13:
   version "18.0.13"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-18.0.13.tgz#0117f1f3d43be7b645192c0f4f431fb4efc4803d"
   integrity sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==
@@ -4856,6 +4851,11 @@ expo-modules-core@3.0.29:
   integrity sha512-LzipcjGqk8gvkrOUf7O2mejNWugPkf3lmd9GkqL9WuNyeN2fRwU0Dn77e3ZUKI3k6sI+DNwjkq4Nu9fNN9WS7Q==
   dependencies:
     invariant "^2.2.4"
+
+expo-screen-orientation@~9.0.9:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/expo-screen-orientation/-/expo-screen-orientation-9.0.9.tgz#74ed82582006f72106b7165512cdfc01367433ba"
+  integrity sha512-UTU745XoqBvQJkZ820GTfMuOxlkppYqaeQ+x0wdu44cyrZiZugqe+egFF2+zC+SaxgAltU5EuO8GIj9xSF+YMw==
 
 expo-secure-store@~15.0.8:
   version "15.0.8"
@@ -8099,13 +8099,6 @@ react-native-worklets@0.5.1:
     "@babel/preset-typescript" "^7.16.7"
     convert-source-map "^2.0.0"
     semver "7.7.2"
-
-react-native-youtube-iframe@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-youtube-iframe/-/react-native-youtube-iframe-2.4.1.tgz#0117093ae7d0cd5b84f6748865bc04c9e1d12069"
-  integrity sha512-MIzVlQYp6sc/Z7b0YwluALd0UbACQ7vscpcVVTmcHvQ5ujN2f6LJdDFxI++xy7TUeJS73k8vBdlznb5bT/P/Gg==
-  dependencies:
-    events "^3.3.0"
 
 react-native@0.79.2:
   version "0.79.2"


### PR DESCRIPTION
Add a World Cup reference corpus and match-specific prompt rules so debates focus on players, news, H2H, and knockout context instead of generic showdowns. Limit feeds to 48 hours, expose Fucci's Take seeded comments in the API, and label them in the debate UI.