### PR TITLE
fix(api): auto-provision system user for Fucci's Take comments

### DIFF
--- a/services/api/internal/api/seeded_comments.go
+++ b/services/api/internal/api/seeded_comments.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log"
 	"strings"
 
@@ -18,6 +19,7 @@ const (
 
 // getSystemUserID returns the system user (Fucci) ID for seeded comments.
 // Tries Config.SystemUserEmail first, then known migration defaults.
+// If none exist, provisions contact@magistri.dev (same as goose migration 20260215000003).
 func (c *Config) getSystemUserID(ctx context.Context) (int32, error) {
 	var candidates []string
 	if email := strings.TrimSpace(c.SystemUserEmail); email != "" {
@@ -38,7 +40,23 @@ func (c *Config) getSystemUserID(ctx context.Context) (int32, error) {
 		}
 		lastErr = err
 	}
-	return 0, lastErr
+	if c.DB == nil {
+		return 0, lastErr
+	}
+	user, err := c.DB.CreateUser(ctx, database.CreateUserParams{
+		Firstname: "Fucci",
+		Lastname:  "System",
+		Email:     defaultSystemUserEmail,
+		IsAdmin:   false,
+	})
+	if err != nil {
+		if user, retryErr := c.DB.GetUserByEmail(ctx, defaultSystemUserEmail); retryErr == nil {
+			return user.ID, nil
+		}
+		return 0, errors.Join(lastErr, err)
+	}
+	log.Printf("[debate] provisioned system user id=%d email=%s", user.ID, defaultSystemUserEmail)
+	return user.ID, nil
 }
 
 func cardText(title, description string) string {

--- a/services/api/internal/api/seeded_comments_test.go
+++ b/services/api/internal/api/seeded_comments_test.go
@@ -92,6 +92,28 @@ func TestGetSystemUserID_FallsBackToDefaultEmail(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestGetSystemUserID_ProvisionsWhenMissing(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT .+ FROM users WHERE email`).
+		WithArgs(defaultSystemUserEmail).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`SELECT .+ FROM users WHERE email`).
+		WithArgs(legacySystemUserEmail).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`INSERT INTO users`).
+		WithArgs("Fucci", "System", defaultSystemUserEmail, false).
+		WillReturnRows(systemUserMockRows(42, defaultSystemUserEmail))
+
+	cfg := &Config{DB: database.New(db)}
+	id, err := cfg.getSystemUserID(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(42), id)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestEnsureSeededComments_InsertsWhenMissing(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)


### PR DESCRIPTION
Staging debates had no seeded comments because the Fucci system user was missing; create it on demand so backfill can run.