### PR TITLE
Disable iPad support for iPhone-only App Store builds.

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,4 +1,4 @@
-# API verification on pull requests — no Fly deploy (see deploy-api.yml).
+# API verification on pull requests — no Fly deploy (see backend-deploy.yml).
 name: API CI
 
 on:

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,8 +1,8 @@
-name: Deploy API to Fly.io (staging)
+name: Backend deploy (Fly.io staging)
 
 # Triggers:
 #   - workflow_dispatch (pick ref)
-#   - pull_request labeled deploy-staging (after review; waits on staging environment approval)
+#   - pull_request labeled backend-deploy (after review; waits on staging environment approval)
 on:
   workflow_dispatch:
     inputs:
@@ -17,7 +17,7 @@ on:
       - main
 
 concurrency:
-  group: deploy-api-${{ github.event.pull_request.number || github.event.inputs.ref || github.ref }}
+  group: backend-deploy-${{ github.event.pull_request.number || github.event.inputs.ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-        github.event.label.name == 'deploy-staging' &&
+        github.event.label.name == 'backend-deploy' &&
         github.event.pull_request.state == 'open' &&
         github.event.pull_request.head.repo.full_name == github.repository)
 
@@ -152,6 +152,6 @@ jobs:
       - name: Job summary
         if: always()
         run: |
-          echo "## API deploy (staging)" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Backend deploy (staging)" >> "$GITHUB_STEP_SUMMARY"
           echo "- Ref: \`${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || format('PR #{0}', github.event.pull_request.number) }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Trigger: \`${{ github.event_name }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1,5 +1,5 @@
-# Staging mobile preview — manual dispatch or PR label deploy-staging (environment approval).
-name: Mobile EAS preview (staging)
+# Staging mobile — manual dispatch or PR label mobile-deploy (environment approval).
+name: Mobile deploy (EAS)
 
 on:
   workflow_dispatch:
@@ -8,6 +8,15 @@ on:
         description: Git ref to build (branch, tag, or SHA)
         required: true
         default: main
+      platform:
+        description: Platform to build
+        required: true
+        default: ios
+        type: choice
+        options:
+          - ios
+          - android
+          - all
   pull_request:
     types:
       - labeled
@@ -15,21 +24,21 @@ on:
       - main
 
 concurrency:
-  group: mobile-preview-${{ github.event.pull_request.number || github.event.inputs.ref || github.ref }}
+  group: mobile-deploy-${{ github.event.pull_request.number || github.event.inputs.ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  ios-preview:
-    name: EAS iOS preview build
+  eas-build:
+    name: EAS build (${{ github.event.inputs.platform || 'ios' }})
     runs-on: ubuntu-latest
     environment: staging
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-        github.event.label.name == 'deploy-staging' &&
+        github.event.label.name == 'mobile-deploy' &&
         github.event.pull_request.state == 'open' &&
         github.event.pull_request.head.repo.full_name == github.repository)
 
@@ -52,7 +61,7 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           if [ -z "$EXPO_TOKEN" ]; then
-            echo "::warning::EXPO_TOKEN secret is not configured — EAS build skipped. Add EXPO_TOKEN to the staging environment (or repository secrets) to enable staging previews."
+            echo "::warning::EXPO_TOKEN secret is not configured — EAS build skipped. Add EXPO_TOKEN to the staging environment (or repository secrets) to enable mobile deploys."
             echo "has_token=false" >> "$GITHUB_OUTPUT"
           else
             HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
@@ -70,22 +79,36 @@ jobs:
         if: steps.validate_token.outputs.has_token == 'true'
         run: yarn install --frozen-lockfile
 
-      - name: EAS build iOS preview
+      - name: Resolve EAS platform
+        if: steps.validate_token.outputs.has_token == 'true'
+        id: platform
+        env:
+          INPUT_PLATFORM: ${{ github.event.inputs.platform }}
+        run: |
+          PLATFORM="${INPUT_PLATFORM:-ios}"
+          echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+
+      - name: EAS build (preview profile)
         if: steps.validate_token.outputs.has_token == 'true'
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: npx eas-cli build --platform ios --profile preview --non-interactive
+        run: |
+          npx eas-cli build \
+            --platform "${{ steps.platform.outputs.platform }}" \
+            --profile preview \
+            --non-interactive
 
       - name: Job summary
         if: always()
         run: |
-          echo "## Mobile preview (staging)" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Mobile deploy (EAS)" >> "$GITHUB_STEP_SUMMARY"
           echo "- Ref: \`${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || format('PR #{0}', github.event.pull_request.number) }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Trigger: \`${{ github.event_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Platform: \`${{ steps.platform.outputs.platform || 'ios' }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.validate_token.outputs.has_token }}" = "true" ]; then
-            echo "Install from the EAS dashboard or re-run with submit after review." >> "$GITHUB_STEP_SUMMARY"
+            echo "Install from the [EAS dashboard](https://expo.dev/accounts) when the build completes." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "⚠️ Build skipped — EXPO_TOKEN secret is missing or invalid. Check the workflow logs for details." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/mobile-testflight.yml
+++ b/.github/workflows/mobile-testflight.yml
@@ -1,16 +1,23 @@
-# Push to main → EAS iOS build + TestFlight submit (no Android).
+# Auto TestFlight on push to main is disabled until the pipeline is fixed.
+# Re-enable by restoring the `push` trigger below.
 name: Mobile TestFlight (main)
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'apps/mobile/**'
-      - '.github/workflows/mobile-testflight.yml'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to build and submit (branch, tag, or SHA)
+        required: true
+        default: main
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'apps/mobile/**'
+  #     - '.github/workflows/mobile-testflight.yml'
 
 concurrency:
-  group: mobile-testflight-${{ github.ref }}
+  group: mobile-testflight-${{ github.event.inputs.ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -24,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -110,5 +119,6 @@ jobs:
         if: always()
         run: |
           echo "## Mobile TestFlight (main)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Ref: \`${{ github.event.inputs.ref || github.ref }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- SHA: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- EAS build: \`${{ steps.eas_build.outputs.build_id }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -78,5 +78,9 @@ module.exports = () => {
   }
 
   expo.extra = extra;
+  expo.ios = {
+    ...(expo.ios || {}),
+    supportsTablet: false,
+  };
   return expo;
 };

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -9,7 +9,7 @@
     "userInterfaceStyle": "light",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true,
+      "supportsTablet": false,
       "requireFullScreen": true,
       "bundleIdentifier": "com.magistridev.fucci",
       "buildNumber": "6",

--- a/services/api/DEPLOYMENT.md
+++ b/services/api/DEPLOYMENT.md
@@ -164,22 +164,22 @@ flyctl deploy
 | Workflow | When it runs |
 | -------- | ------------ |
 | **API CI** (`api-ci.yml`) | Every PR to `main` that touches `services/api/**` — tests only |
-| **Deploy API** (`deploy-api.yml`) | Manual **workflow_dispatch**, or add label `deploy-staging` on a PR (requires **`staging` environment** approval) |
-| **Mobile TestFlight** (`mobile-testflight.yml`) | Push to `main` with `apps/mobile/**` changes — iOS build + TestFlight submit |
-| **Mobile preview** (`mobile-preview-deploy.yml`) | Manual dispatch, or PR label `deploy-staging` (requires **`staging` environment** approval) |
+| **Backend deploy** (`backend-deploy.yml`) | Manual **workflow_dispatch**, or add label `backend-deploy` on a PR (requires **`staging` environment** approval) |
+| **Mobile deploy** (`mobile-deploy.yml`) | Manual **workflow_dispatch** (iOS / Android / all), or PR label `mobile-deploy` (requires **`staging` environment** approval) |
+| **Mobile TestFlight** (`mobile-testflight.yml`) | Manual **workflow_dispatch** only (auto deploy on push to `main` is disabled until the pipeline is fixed) |
 
 **Setup GitHub Secrets** (Settings → Secrets and variables → Actions):
 
 - `FLY_API_TOKEN`, `DB_URL`, `SUPABASE_*`, etc. for API deploy
-- `EXPO_TOKEN`, `ASC_APP_ID`, `ASC_API_KEY_*` for mobile TestFlight / preview
+- `EXPO_TOKEN`, `ASC_APP_ID`, `ASC_API_KEY_*` for mobile TestFlight / EAS builds
 
 **Environment protection** (Settings → Environments):
 
-- **`staging`** — required reviewers before Fly deploy and EAS preview builds on PRs
+- **`staging`** — required reviewers before Fly deploy and EAS builds triggered from PR labels
 
-**After code review on a PR:** add the `deploy-staging` label (or run **Deploy API** / **Mobile EAS preview** manually from Actions with the PR branch as `ref`).
+**After code review on a PR:** add `backend-deploy` and/or `mobile-deploy` (or run **Backend deploy** / **Mobile deploy** manually from Actions with the PR branch as `ref`).
 
-**After merge to `main`:** mobile changes auto-submit to TestFlight; API deploy remains manual until you run **Deploy API** with `ref: main`.
+**After merge to `main`:** API and mobile deploys are manual — use **Backend deploy** or **Mobile deploy** from Actions with `ref: main`. TestFlight auto-submit on merge is disabled for now.
 
 **iOS build numbers:** The `preview` profile uses EAS remote versioning with `autoIncrement: true` — EAS bumps `ios.buildNumber` on each preview/TestFlight build. Bump `expo.version` in `app.json` manually when you want a new user-facing version (e.g. `1.1.0` → `1.2.0`).
 


### PR DESCRIPTION
Set supportsTablet to false in app config so the iOS target is iPhone-only and iPad screenshots are not required.