### PR TITLE
Restore all-league Matches and make MLS the temporary default.

### DIFF
--- a/apps/mobile/src/config/featureFlags.ts
+++ b/apps/mobile/src/config/featureFlags.ts
@@ -18,7 +18,7 @@
  * seasons are all over until ~August 2026. Flip this to `false` when the new
  * club season starts.
  */
-export const WORLD_CUP_ONLY_MODE = true;
+export const WORLD_CUP_ONLY_MODE = false;
 
 /**
  * Media-outlet YouTube Shorts story rings (FOX SPORTS, ESPN FC, Telemundo Deportes, etc.).

--- a/apps/mobile/src/config/featureFlags.ts
+++ b/apps/mobile/src/config/featureFlags.ts
@@ -18,7 +18,7 @@
  * seasons are all over until ~August 2026. Flip this to `false` when the new
  * club season starts.
  */
-export const WORLD_CUP_ONLY_MODE = false;
+export const WORLD_CUP_ONLY_MODE = false; // Note: News feed/strip behavior is no longer controlled by this flag.
 
 /**
  * Media-outlet YouTube Shorts story rings (FOX SPORTS, ESPN FC, Telemundo Deportes, etc.).

--- a/apps/mobile/src/constants/leagues.ts
+++ b/apps/mobile/src/constants/leagues.ts
@@ -8,6 +8,9 @@ export interface League {
 /** API-Football league id for UEFA Champions League. */
 export const UCL_LEAGUE_ID = 2;
 
+/** API-Football league id for Major League Soccer. */
+export const MLS_LEAGUE_ID = 253;
+
 /** API-Football league id for the FIFA World Cup. */
 export const WORLD_CUP_LEAGUE_ID = 1;
 
@@ -27,6 +30,8 @@ const L = (leagueId: number) =>
   `https://media.api-sports.io/football/leagues/${leagueId}.png`;
 
 export const LEAGUES: League[] = [
+  // Temporary: MLS first / default until Premier League season starts.
+  {id: MLS_LEAGUE_ID, name: 'MLS', logo: L(MLS_LEAGUE_ID)},
   {id: 39, name: 'Premier League', logo: L(39)},
   {id: 140, name: 'La Liga', logo: L(140)},
   {id: 135, name: 'Serie A', logo: L(135)},
@@ -37,7 +42,7 @@ export const LEAGUES: League[] = [
   {id: 0, name: 'International Competitions', logo: L(1)},
 ];
 
-export const DEFAULT_LEAGUE = LEAGUES[0]; // Premier League
+export const DEFAULT_LEAGUE = LEAGUES[0]; // MLS (swap back to Premier League when season starts)
 
 /**
  * Standalone "FIFA World Cup" entry used by Summer-2026 world-cup-only mode.
@@ -58,6 +63,7 @@ export function leagueStripLabel(name: string): string {
     'Serie A': 'SERIE A',
     Bundesliga: 'BUNDES',
     'Ligue 1': 'LIGUE 1',
+    MLS: 'MLS',
     'UEFA Champions League': 'UCL',
     'International Competitions': 'INTL',
   };

--- a/apps/mobile/src/screens/NewsScreen.tsx
+++ b/apps/mobile/src/screens/NewsScreen.tsx
@@ -236,23 +236,16 @@ const NewsScreen: React.FC = () => {
           />
         ) : null}
 
-        {articles.length === 0 ? (
-          <View style={styles.emptyFilter}>
-            <Text style={styles.emptyFilterText}>No articles right now</Text>
-            <Text style={styles.emptyFilterHint}>Pull down to refresh</Text>
+        <>
+          {featured ? renderFeatured(featured) : null}
+          <View style={styles.grid}>
+            {gridArticles.map(a => (
+              <View key={a.id} style={{width: GRID_COL_W}}>
+                {renderGridCard(a)}
+              </View>
+            ))}
           </View>
-        ) : (
-          <>
-            {featured ? renderFeatured(featured) : null}
-            <View style={styles.grid}>
-              {gridArticles.map(a => (
-                <View key={a.id} style={{width: GRID_COL_W}}>
-                  {renderGridCard(a)}
-                </View>
-              ))}
-            </View>
-          </>
-        )}
+        </>
       </ScrollView>
     </View>
   );
@@ -468,22 +461,6 @@ const styles = StyleSheet.create({
     color: NEWS_ACCENT,
     fontSize: 16,
     fontWeight: '700',
-  },
-  emptyFilter: {
-    padding: 24,
-    alignItems: 'center',
-  },
-  emptyFilterText: {
-    color: NEWS_TEXT,
-    fontSize: 15,
-    fontWeight: '600',
-    textAlign: 'center',
-  },
-  emptyFilterHint: {
-    color: NEWS_MUTED,
-    fontSize: 13,
-    marginTop: 8,
-    textAlign: 'center',
   },
 });
 

--- a/apps/mobile/src/screens/NewsScreen.tsx
+++ b/apps/mobile/src/screens/NewsScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useMemo, useRef, useEffect} from 'react';
+import React, {useState, useCallback, useMemo, useRef} from 'react';
 import {
   View,
   Text,
@@ -17,11 +17,7 @@ import {LinearGradient} from 'expo-linear-gradient';
 import type {NavigationProp} from '../types/navigation';
 import {useNews} from '../hooks/useNews';
 import type {NewsArticle} from '../types/news';
-import {WORLD_CUP_LEAGUE, type League} from '../constants/leagues';
-import {
-  MEDIA_STORY_RINGS_ENABLED,
-  WORLD_CUP_ONLY_MODE,
-} from '../config/featureFlags';
+import {MEDIA_STORY_RINGS_ENABLED} from '../config/featureFlags';
 import {
   NEWS_BG,
   NEWS_CARD,
@@ -31,11 +27,9 @@ import {
   NEWS_MUTED,
   NEWS_EXCLUSIVE,
 } from '../constants/newsUi';
-import {LeagueHorizontalStrip} from '../components/LeagueHorizontalStrip';
 import {MediaStoryRings} from '../components/MediaStoryRings';
 import {
   mergeAndSortArticles,
-  filterByLeague,
   articleCategoryLabel,
 } from '../utils/newsFilters';
 import {userFacingApiMessage} from '../services/api';
@@ -49,9 +43,6 @@ const NewsScreen: React.FC = () => {
   const navigation = useNavigation<NavigationProp>();
   const scrollRef = useRef<ScrollView>(null);
   const [failedImageIds, setFailedImageIds] = useState<Set<string>>(new Set());
-  const [leagueFilter, setLeagueFilter] = useState<League | null>(
-    WORLD_CUP_ONLY_MODE ? WORLD_CUP_LEAGUE : null,
-  );
   const {
     todayArticles,
     historyArticles,
@@ -77,21 +68,13 @@ const NewsScreen: React.FC = () => {
     [navigation],
   );
 
-  const merged = useMemo(
+  const articles = useMemo(
     () => mergeAndSortArticles(todayArticles, historyArticles),
     [todayArticles, historyArticles],
   );
 
-  const filteredArticles = useMemo(() => {
-    return filterByLeague(merged, leagueFilter);
-  }, [merged, leagueFilter]);
-
-  useEffect(() => {
-    scrollRef.current?.scrollTo({y: 0, animated: true});
-  }, [leagueFilter?.id]);
-
-  const featured = filteredArticles[0];
-  const gridArticles = filteredArticles.slice(1);
+  const featured = articles[0];
+  const gridArticles = articles.slice(1);
 
   const renderFeatured = (article: NewsArticle) => {
     const imgOk = Boolean(article.imageUrl && !failedImageIds.has(article.id));
@@ -185,7 +168,7 @@ const NewsScreen: React.FC = () => {
     );
   };
 
-  if (loading && merged.length === 0) {
+  if (loading && articles.length === 0) {
     return (
       <View style={styles.centerContainer}>
         <ActivityIndicator size="large" color={NEWS_ACCENT} />
@@ -194,7 +177,7 @@ const NewsScreen: React.FC = () => {
     );
   }
 
-  if (error && merged.length === 0) {
+  if (error && articles.length === 0) {
     return (
       <View style={styles.centerContainer}>
         <Ionicons name="alert-circle-outline" size={48} color="#ff6b6b" />
@@ -214,7 +197,7 @@ const NewsScreen: React.FC = () => {
     );
   }
 
-  if (!loading && merged.length === 0) {
+  if (!loading && articles.length === 0) {
     return (
       <View style={styles.centerContainer}>
         <Ionicons name="newspaper-outline" size={48} color={NEWS_MUTED} />
@@ -253,28 +236,10 @@ const NewsScreen: React.FC = () => {
           />
         ) : null}
 
-        {WORLD_CUP_ONLY_MODE ? null : (
-          <LeagueHorizontalStrip
-            selectedLeague={leagueFilter}
-            onSelect={setLeagueFilter}
-            includeAllOption
-            accentColor={NEWS_ACCENT}
-            mutedColor={NEWS_MUTED}
-          />
-        )}
-
-        {filteredArticles.length === 0 ? (
+        {articles.length === 0 ? (
           <View style={styles.emptyFilter}>
-            <Text style={styles.emptyFilterText}>
-              {WORLD_CUP_ONLY_MODE
-                ? 'No World Cup articles right now'
-                : 'No articles match these filters'}
-            </Text>
-            <Text style={styles.emptyFilterHint}>
-              {WORLD_CUP_ONLY_MODE
-                ? 'Pull down to refresh'
-                : 'Try another league filter'}
-            </Text>
+            <Text style={styles.emptyFilterText}>No articles right now</Text>
+            <Text style={styles.emptyFilterHint}>Pull down to refresh</Text>
           </View>
         ) : (
           <>

--- a/apps/mobile/src/services/matchesDefaultLeague.ts
+++ b/apps/mobile/src/services/matchesDefaultLeague.ts
@@ -1,5 +1,4 @@
-import {fetchMatches} from './futbol';
-import {LEAGUES, UCL_LEAGUE_ID, seasonParamForMatchSearch} from '../constants/leagues';
+import {LEAGUES, MLS_LEAGUE_ID} from '../constants/leagues';
 import type {League} from '../constants/leagues';
 
 function requireLeague(id: number): League {
@@ -10,8 +9,7 @@ function requireLeague(id: number): League {
   return league;
 }
 
-const PREMIER_LEAGUE = requireLeague(39);
-const UCL_LEAGUE = requireLeague(UCL_LEAGUE_ID);
+const MLS_LEAGUE = requireLeague(MLS_LEAGUE_ID);
 
 function calendarDayKey(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
@@ -22,15 +20,16 @@ function calendarDayKey(d: Date): string {
 /** One resolved default per calendar day per app session (avoids repeat probes on Home remount). */
 let sessionDefaultLeagueByDay: {dayKey: string; league: League} | null = null;
 
-/** Sat / Sun / Mon → Premier League is the default strip selection on Home. */
+/** Sat / Sun / Mon → Premier League preferred (re-enable with PL-season default logic). */
 export function isPremierLeaguePreferredDay(d: Date): boolean {
   const day = d.getDay();
   return day === 0 || day === 1 || day === 6;
 }
 
 /**
- * Tue–Fri: default to UCL if there is at least one UCL fixture **today** (single fetch),
- * else Premier League. Sat–Mon always Premier League (no network).
+ * Home Matches strip default.
+ * Temporary: always MLS until the Premier League season starts, then restore
+ * Sat–Mon → Premier League / Tue–Fri → UCL if fixtures today else Premier.
  */
 export async function resolveHomeScreenDefaultLeague(
   todayLocal: Date,
@@ -46,18 +45,6 @@ export async function resolveHomeScreenDefaultLeague(
     return sessionDefaultLeagueByDay.league;
   }
 
-  if (isPremierLeaguePreferredDay(today)) {
-    sessionDefaultLeagueByDay = {dayKey, league: PREMIER_LEAGUE};
-    return PREMIER_LEAGUE;
-  }
-
-  const rows = await fetchMatches(
-    today,
-    UCL_LEAGUE_ID,
-    seasonParamForMatchSearch(UCL_LEAGUE, today),
-  );
-  const league =
-    rows != null && rows.length > 0 ? UCL_LEAGUE : PREMIER_LEAGUE;
-  sessionDefaultLeagueByDay = {dayKey, league};
-  return league;
+  sessionDefaultLeagueByDay = {dayKey, league: MLS_LEAGUE};
+  return MLS_LEAGUE;
 }

--- a/apps/mobile/src/services/matchesDefaultLeague.ts
+++ b/apps/mobile/src/services/matchesDefaultLeague.ts
@@ -20,12 +20,6 @@ function calendarDayKey(d: Date): string {
 /** One resolved default per calendar day per app session (avoids repeat probes on Home remount). */
 let sessionDefaultLeagueByDay: {dayKey: string; league: League} | null = null;
 
-/** Sat / Sun / Mon → Premier League preferred (re-enable with PL-season default logic). */
-export function isPremierLeaguePreferredDay(d: Date): boolean {
-  const day = d.getDay();
-  return day === 0 || day === 1 || day === 6;
-}
-
 /**
  * Home Matches strip default.
  * Temporary: always MLS until the Premier League season starts, then restore

--- a/apps/mobile/src/utils/newsFilters.ts
+++ b/apps/mobile/src/utils/newsFilters.ts
@@ -103,6 +103,7 @@ const LEAGUE_KEYWORDS: Record<number, string[]> = {
   135: ['serie a', ' italy ', 'italian'],
   78: ['bundesliga', ' germany ', 'german'],
   61: ['ligue 1', ' ligue  ', ' france ', 'french'],
+  253: [' mls ', 'major league soccer', 'inter miami', 'la galaxy'],
   2: ['champions league', ' ucl ', 'european'],
   1: [...WORLD_CUP_KEYWORDS],
   0: [

--- a/services/api/internal/api/football_season.go
+++ b/services/api/internal/api/football_season.go
@@ -9,6 +9,10 @@ import (
 // as other club leagues; optional `season` query on /futbol/matches overrides.
 const LeagueUEFAChampionsLeague = 2
 
+// LeagueMLS is API-Football v3 id for Major League Soccer.
+// MLS runs on a calendar year; API-Football `season` is that year (2026 → 2026).
+const LeagueMLS = 253
+
 // API-Football v3 league IDs for international tournaments (national teams).
 // See https://www.api-football.com/documentation-v3 — verify via GET /leagues if fixtures look wrong.
 const (
@@ -33,6 +37,12 @@ var internationalFootballLeagueIDs = map[int]struct{}{
 	LeagueWCQOFC:      {},
 }
 
+// Club leagues whose API-Football `season` is the calendar year of the fixture
+// (not the European Aug–July start year).
+var calendarYearClubLeagueIDs = map[int]struct{}{
+	LeagueMLS: {},
+}
+
 // IsInternationalFootballLeague is true for World Cup, WCQ confederations, and international friendlies.
 // Domestic and club competitions (EPL, UCL, etc.) use the August–July season year rule instead.
 func IsInternationalFootballLeague(leagueID int) bool {
@@ -40,13 +50,22 @@ func IsInternationalFootballLeague(leagueID int) bool {
 	return ok
 }
 
+// usesCalendarYearSeason is true when API-Football expects season = fixture calendar year.
+func usesCalendarYearSeason(leagueID int) bool {
+	if IsInternationalFootballLeague(leagueID) {
+		return true
+	}
+	_, ok := calendarYearClubLeagueIDs[leagueID]
+	return ok
+}
+
 // ResolveAPIFootballSeason returns the `season` query parameter for API-Football fixtures.
-// - UEFA Champions League and domestic club leagues: European-style season starting year
+// - UEFA Champions League and most domestic club leagues: European-style season starting year
 //   (Aug–Dec → year; Jan–Jul → year−1).
-// - International tournaments (national teams): calendar year of the fixture date.
+// - International tournaments and calendar-year club leagues (e.g. MLS): calendar year of the fixture date.
 func ResolveAPIFootballSeason(leagueID int, matchDate time.Time) int {
 	y, m, _ := matchDate.Date()
-	if IsInternationalFootballLeague(leagueID) {
+	if usesCalendarYearSeason(leagueID) {
 		return y
 	}
 	if m >= time.August {

--- a/services/api/internal/api/football_season_test.go
+++ b/services/api/internal/api/football_season_test.go
@@ -42,3 +42,15 @@ func TestResolveAPIFootballSeason_International(t *testing.T) {
 		t.Fatalf("WCQ UEFA: got %d want 2026", g)
 	}
 }
+
+func TestResolveAPIFootballSeason_MLS(t *testing.T) {
+	// MLS is a calendar-year league; July 2026 fixtures use season 2026 (not 2025).
+	jul := time.Date(2026, time.July, 25, 0, 0, 0, 0, time.UTC)
+	if g := ResolveAPIFootballSeason(LeagueMLS, jul); g != 2026 {
+		t.Fatalf("MLS July 2026: got %d want 2026", g)
+	}
+	jan := time.Date(2026, time.January, 10, 0, 0, 0, 0, time.UTC)
+	if g := ResolveAPIFootballSeason(LeagueMLS, jan); g != 2026 {
+		t.Fatalf("MLS January 2026: got %d want 2026", g)
+	}
+}

--- a/services/api/internal/api/futbol_test.go
+++ b/services/api/internal/api/futbol_test.go
@@ -1111,6 +1111,27 @@ func TestGetMatchesSeasonResolutionAndCache(t *testing.T) {
 		}
 	})
 
+	t.Run("computed season MLS uses calendar year", func(t *testing.T) {
+		var gotPath string
+		srv := newMatchServer(t, func(path string) { gotPath = path })
+		defer srv.Close()
+		config := &Config{
+			Cache:              mockCacheMiss(t, nil, nil),
+			FootballAPIKey:     "key",
+			APIFootballBaseURL: srv.URL,
+		}
+		req := httptest.NewRequest("GET", "/matches", nil)
+		req.URL.RawQuery = "date=2026-07-25&league_id=253"
+		rec := httptest.NewRecorder()
+		config.getMatches(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("code = %d", rec.Code)
+		}
+		if !strings.Contains(gotPath, "league=253") || !strings.Contains(gotPath, "season=2026") {
+			t.Fatalf("upstream URL want league=253 and season=2026; got %q", gotPath)
+		}
+	})
+
 	t.Run("explicit season override used for URL and cache key", func(t *testing.T) {
 		var gotPath string
 		var existsKey, setKey string


### PR DESCRIPTION
Turn off World Cup-only mode, add MLS with calendar-year season resolution, remove the News league strip, and default Home to MLS until Premier League returns.