### PR TITLE
Address App Review: account deletion and clearer privacy strings.

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -16,6 +16,8 @@
       "infoPlist": {
         "NSCameraUsageDescription": "Fucci uses the camera so you can take a new profile photo or capture photos and videos for Match Stories.",
         "NSPhotoLibraryUsageDescription": "Fucci uses your photo library so you can choose an existing image as your profile photo or add media to Match Stories.",
+        "NSPhotoLibraryAddUsageDescription": "Fucci saves captured Match Story media to your photo library.",
+        "NSMicrophoneUsageDescription": "Fucci uses the microphone to record audio when capturing Match Story videos.",
         "ITSAppUsesNonExemptEncryption": false,
         "NSUserNotificationsUsageDescription": "Allow Fucci to send match, news, and debate alerts you opt into."
       }

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -14,8 +14,8 @@
       "bundleIdentifier": "com.magistridev.fucci",
       "buildNumber": "6",
       "infoPlist": {
-        "NSCameraUsageDescription": "Allow Fucci to access your camera to take profile photos.",
-        "NSPhotoLibraryUsageDescription": "Allow Fucci to access your photo library to choose profile photos.",
+        "NSCameraUsageDescription": "Fucci uses the camera so you can take a new profile photo or capture photos and videos for Match Stories.",
+        "NSPhotoLibraryUsageDescription": "Fucci uses your photo library so you can choose an existing image as your profile photo or add media to Match Stories.",
         "ITSAppUsesNonExemptEncryption": false,
         "NSUserNotificationsUsageDescription": "Allow Fucci to send match, news, and debate alerts you opt into."
       }

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 import {
   View,
   Text,
@@ -6,6 +6,7 @@ import {
   ScrollView,
   TouchableOpacity,
   Alert,
+  ActivityIndicator,
 } from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useNavigation} from '@react-navigation/native';
@@ -17,6 +18,7 @@ import {dispatchResetToMainProfileTab} from '../navigation/authNavigationActions
 import type {RootStackParamList} from '../types/navigation';
 import PushNotificationSettings from '../components/PushNotificationSettings';
 import {logoutWithPushCleanup} from '../hooks/usePushNotifications';
+import {deleteAccount, userFacingApiMessage} from '../services/api';
 
 const LIME = '#c7f349';
 const CYAN = '#22d3ee';
@@ -25,6 +27,7 @@ const CARD = '#0b1224';
 const CARD_BORDER = '#1f2937';
 const MUTED = '#64748b';
 const TEXT = '#e2e8f0';
+const DANGER = '#f87171';
 
 type Nav = NativeStackNavigationProp<RootStackParamList>;
 
@@ -33,6 +36,7 @@ const APP_NAME = 'FUCCI';
 export default function SettingsScreen() {
   const navigation = useNavigation<Nav>();
   const {logout: authLogout, isLoggedIn, token} = useAuth();
+  const [isDeletingAccount, setIsDeletingAccount] = useState(false);
 
   const appVersion =
     Constants.expoConfig?.version ??
@@ -53,6 +57,56 @@ export default function SettingsScreen() {
       },
     ]);
   }, [authLogout, navigation, token]);
+
+  const performDeleteAccount = useCallback(async () => {
+    if (!token || isDeletingAccount) {
+      return;
+    }
+    setIsDeletingAccount(true);
+    try {
+      await deleteAccount(token);
+      await logoutWithPushCleanup(null, authLogout);
+      navigation.goBack();
+      dispatchResetToMainProfileTab();
+    } catch (error) {
+      Alert.alert('Could not delete account', userFacingApiMessage(error));
+    } finally {
+      setIsDeletingAccount(false);
+    }
+  }, [authLogout, isDeletingAccount, navigation, token]);
+
+  const handleDeleteAccount = useCallback(() => {
+    if (!token || isDeletingAccount) {
+      return;
+    }
+    Alert.alert(
+      'Delete account?',
+      'This permanently deletes your account and associated data. This cannot be undone.',
+      [
+        {text: 'Cancel', style: 'cancel'},
+        {
+          text: 'Continue',
+          style: 'destructive',
+          onPress: () => {
+            Alert.alert(
+              'Confirm deletion',
+              'Are you sure you want to permanently delete your Fucci account?',
+              [
+                {text: 'Cancel', style: 'cancel'},
+                {
+                  text: 'Delete Account',
+                  style: 'destructive',
+                  onPress: () => {
+                    void performDeleteAccount();
+                  },
+                },
+              ],
+            );
+          },
+        },
+      ],
+    );
+  }, [isDeletingAccount, performDeleteAccount, token]);
 
   return (
     <SafeAreaView style={styles.safe} edges={['top']}>
@@ -103,7 +157,7 @@ export default function SettingsScreen() {
           <SettingsRow
             icon="shield-checkmark-outline"
             title="Privacy Encryption"
-            last
+            last={!isLoggedIn}
             onPress={() =>
               Alert.alert(
                 'Privacy',
@@ -111,6 +165,16 @@ export default function SettingsScreen() {
               )
             }
           />
+          {isLoggedIn ? (
+            <SettingsRow
+              icon="trash-outline"
+              title="Delete Account"
+              danger
+              last
+              onPress={handleDeleteAccount}
+              disabled={isDeletingAccount}
+            />
+          ) : null}
         </View>
 
         <PushNotificationSettings showHeader />
@@ -147,10 +211,18 @@ export default function SettingsScreen() {
           <TouchableOpacity
             style={styles.logoutCta}
             onPress={handleLogout}
-            activeOpacity={0.9}>
+            activeOpacity={0.9}
+            disabled={isDeletingAccount}>
             <Ionicons name="log-out-outline" size={22} color="#0f172a" />
             <Text style={styles.logoutCtaText}>LOGOUT OF SESSION</Text>
           </TouchableOpacity>
+        ) : null}
+
+        {isDeletingAccount ? (
+          <View style={styles.deletingRow}>
+            <ActivityIndicator color={DANGER} />
+            <Text style={styles.deletingText}>Deleting account…</Text>
+          </View>
         ) : null}
 
         <View style={{height: 32}} />
@@ -173,19 +245,27 @@ function SettingsRow({
   title,
   onPress,
   last,
+  danger,
+  disabled,
 }: {
   icon: string;
   title: string;
   onPress: () => void;
   last?: boolean;
+  danger?: boolean;
+  disabled?: boolean;
 }) {
+  const tint = danger ? DANGER : CYAN;
   return (
     <TouchableOpacity
-      style={[styles.row, !last && styles.rowBorder]}
+      style={[styles.row, !last && styles.rowBorder, disabled && styles.rowDisabled]}
       onPress={onPress}
-      activeOpacity={0.75}>
-      <Ionicons name={icon as any} size={20} color={CYAN} />
-      <Text style={styles.rowTitle}>{title}</Text>
+      activeOpacity={0.75}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={title}>
+      <Ionicons name={icon as any} size={20} color={tint} />
+      <Text style={[styles.rowTitle, danger && styles.rowTitleDanger]}>{title}</Text>
       <Ionicons name="chevron-forward" size={18} color={MUTED} />
     </TouchableOpacity>
   );
@@ -305,6 +385,12 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: TEXT,
   },
+  rowTitleDanger: {
+    color: DANGER,
+  },
+  rowDisabled: {
+    opacity: 0.5,
+  },
   supportTitle: {
     flex: 1,
     fontSize: 15,
@@ -333,5 +419,18 @@ const styles = StyleSheet.create({
     fontWeight: '900',
     letterSpacing: 1.2,
     color: '#0f172a',
+  },
+  deletingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    marginTop: 12,
+    marginBottom: 8,
+  },
+  deletingText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: DANGER,
   },
 });

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -216,6 +216,7 @@ export {
   getProfile,
   updateProfile,
   getFollowing,
+  deleteAccount,
   type RegisterRequest,
   type RegisterResponse,
   type LoginRequest,

--- a/apps/mobile/src/services/auth.ts
+++ b/apps/mobile/src/services/auth.ts
@@ -161,3 +161,8 @@ export const getFollowing = async (token: string): Promise<FollowingItem[]> => {
     return [];
   }
 };
+
+// DELETE /users/account (auth required) — permanently deletes the signed-in user
+export const deleteAccount = async (token: string): Promise<void> => {
+  await makeAuthRequest(token, '/users/account', 'DELETE');
+};

--- a/services/api/internal/api/api.go
+++ b/services/api/internal/api/api.go
@@ -196,6 +196,7 @@ func New(c *Config) http.Handler {
 	userRouter.Use(auth.RequireAuth)
 	userRouter.Get("/profile", c.handleGetProfile)
 	userRouter.Put("/profile", c.handleUpdateProfile)
+	userRouter.Delete("/account", c.handleDeleteAccount)
 	userRouter.Get("/me/following", c.handleGetFollowing)
 
 	// Temp route for listing all users

--- a/services/api/internal/api/auth.go
+++ b/services/api/internal/api/auth.go
@@ -872,6 +872,28 @@ func (c *Config) handleGetFollowing(w http.ResponseWriter, r *http.Request) {
 	respondWithJSON(w, http.StatusOK, GetFollowingResponse{Items: items})
 }
 
+// handleDeleteAccount permanently deletes the authenticated user's account and cascaded data.
+// DELETE /users/account
+func (c *Config) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		respondWithError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	if c.DB == nil {
+		respondWithError(w, http.StatusInternalServerError, "database not configured")
+		return
+	}
+
+	if err := c.DB.DeleteUser(r.Context(), userID); err != nil {
+		log.Printf("delete account user=%d: %v", userID, err)
+		respondWithError(w, http.StatusInternalServerError, "failed to delete account")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (c *Config) handleGetProfile(w http.ResponseWriter, r *http.Request) {
 	// Get user ID from context (set by auth middleware)
 	userID, ok := auth.UserIDFromContext(r.Context())

--- a/services/api/internal/api/auth_test.go
+++ b/services/api/internal/api/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -165,6 +166,32 @@ func TestHandleDeleteAccount_DBNotConfigured(t *testing.T) {
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteAccount_DBError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	const userID int32 = 42
+	mock.ExpectExec(`DELETE FROM users WHERE id = \$1`).
+		WithArgs(userID).
+		WillReturnError(fmt.Errorf("db error"))
+
+	cfg := &Config{DB: database.New(db)}
+	rec := httptest.NewRecorder()
+	req := authTestRequest(http.MethodDelete, "/users/account", nil, userID)
+
+	cfg.handleDeleteAccount(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
 	}
 }
 

--- a/services/api/internal/api/auth_test.go
+++ b/services/api/internal/api/auth_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/ArronJLinton/fucci-api/internal/auth"
+	"github.com/ArronJLinton/fucci-api/internal/database"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 // fakeProfileUpdatePersistence records ExecUpdate and returns a canned UserResponse from LoadUserResponse.
@@ -139,5 +141,55 @@ func TestHandleUpdateProfile_AvatarURLReturns500WhenCloudinaryCloudNameUnset(t *
 	body := rec.Body.String()
 	if !strings.Contains(body, "cloud name is not configured") {
 		t.Fatalf("expected configuration error in body, got %q", body)
+	}
+}
+
+func TestHandleDeleteAccount_Unauthorized(t *testing.T) {
+	cfg := &Config{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/users/account", nil)
+
+	cfg.handleDeleteAccount(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteAccount_DBNotConfigured(t *testing.T) {
+	cfg := &Config{}
+	rec := httptest.NewRecorder()
+	req := authTestRequest(http.MethodDelete, "/users/account", nil, 42)
+
+	cfg.handleDeleteAccount(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteAccount_OK(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	const userID int32 = 42
+	mock.ExpectExec(`DELETE FROM users WHERE id = \$1`).
+		WithArgs(userID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	cfg := &Config{DB: database.New(db)}
+	rec := httptest.NewRecorder()
+	req := authTestRequest(http.MethodDelete, "/users/account", nil, userID)
+
+	cfg.handleDeleteAccount(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
 	}
 }


### PR DESCRIPTION
Add hard-delete account from Settings via DELETE /users/account, and update camera/photo purpose strings to cover profile photos and Match Stories.